### PR TITLE
custom installation of patched k8s client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ install:
 	/usr/bin/env python3 setup.py install
 
 zipapp:
-	shiv --compressed -o pygluu-kubernetes.pyz -p '/usr/bin/env python3' -e pygluu.kubernetes.create:main . -r requirements.txt --no-cache
+	shiv --compressed -o pygluu-kubernetes.pyz -p '/usr/bin/env python3' -e pygluu.kubernetes.create:main pygluu/kubernetes/templates/kubernetesv11.0.0.tar.gz . --no-cache

--- a/pygluu/kubernetes/create.py
+++ b/pygluu/kubernetes/create.py
@@ -4,12 +4,12 @@
  Installs Gluu
 """
 # TODO: Delete this script as soon as the kubernetes python client fixes CRD issue
-from .installclient import install_kubernetes_client_11_0_0
+# from .installclient import install_kubernetes_client_11_0_0
 
-try:
-    from .kubeapi import Kubernetes
-except ImportError:
-    install_kubernetes_client_11_0_0()
+# try:
+#     from .kubeapi import Kubernetes
+# except ImportError:
+#     install_kubernetes_client_11_0_0()
 # End of section to be removed. TODO
 import argparse
 import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 --index-url https://pypi.python.org/simple/
-
+# install patched kubernetes client
+pygluu/kubernetes/templates/kubernetesv11.0.0.tar.gz
 -e .

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,14 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
+def get_k8s_pkg():
+    # get local version (forked) kubernetes version
+    # see Local version segments https://www.python.org/dev/peps/pep-0440/#id43
+    here = os.path.abspath(os.path.dirname(__file__))
+    k8s_pkg = os.path.join(here, "pygluu", "kubernetes", "templates", "kubernetesv11.0.0.tar.gz")
+    return f"file:///{k8s_pkg}#egg=kubernetes-11.0.0"
+
+
 setup(
     name="pygluu-kubernetes",
     version=find_version("pygluu", "kubernetes", "__init__.py"),
@@ -39,18 +47,22 @@ setup(
         "ruamel.yaml>=0.16.5",
         "pyOpenSSL>=19.1.0",
         "cryptography>=2.8",
-        "requests",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
         "pyDes>=2.0.0",  # TODO: Remove the following as soon as the update secret is moved to backend
-        "google-api-python-client>=1.8.0", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
-        "requests_oauthlib>=1.3.0", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
-        "certifi>=14.05.14", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
-        "six>=1.9.0", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
-        "python-dateutil>=2.5.3", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
-        "setuptools>=46.1.3", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
-        "pyyaml>=3.12", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
-        "google-auth>=1.0.1", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
-        "ipaddress>=1.0.17;python_version=='2.7'", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
-        "websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*", # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "requests",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "google-api-python-client>=1.8.0",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "requests_oauthlib>=1.3.0",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "certifi>=14.05.14",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "six>=1.9.0",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "python-dateutil>=2.5.3",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "setuptools>=46.1.3",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "pyyaml>=3.12",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "google-auth>=1.0.1",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "ipaddress>=1.0.17;python_version=='2.7'",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
+        "kubernetes==11.0.0",
+    ],
+    dependency_links=[
+        get_k8s_pkg(),  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
     ],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
The following changes allow installing kubernetes client from `.tar.gz` file.

Due to different implementation, the changes are mainly consists of:

1. `dependency_links` is added to `setup.py` for discovering package inside `.tar.gz`
1. enable `pip` to install from `.tar.gz`
1. enable `shiv` to install from `.tar.gz`
