### PR TITLE
partially replace builtins.input with click's prompt and confirm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         "ipaddress>=1.0.17;python_version=='2.7'",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
         "websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*",  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream
         "kubernetes==11.0.0",
+
+        "Click!=7.0,>=6.7",
     ],
     dependency_links=[
         get_k8s_pkg(),  # TODO: Remove the following as soon as the kubernetes python client is fixed upstream

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -18,6 +18,17 @@ def prompter():
             os.unlink(file_)
 
 
+@pytest.mark.parametrize("given, expected", [
+    (True, "Y"),
+    (False, "N"),
+])
+def test_confirm_yesno(monkeypatch, given, expected):
+    from pygluu.kubernetes.prompt import confirm_yesno
+
+    monkeypatch.setattr("click.confirm", lambda x: given)
+    assert confirm_yesno("Random question") == expected
+
+
 def test_prompt_license_no_prompt(prompter):
     prompter.prompt_license()
     assert prompter.settings["ACCEPT_GLUU_LICENSE"] == "Y"
@@ -33,7 +44,7 @@ def test_prompt_version_no_prompt(prompter):
     ("4.2.0_dev", "4.2.0_dev"),
 ])
 def test_prompt_version(monkeypatch, prompter, given, expected):
-    monkeypatch.setattr("builtins.input", lambda x: given)
+    monkeypatch.setattr("click.prompt", lambda x, default: given or expected)
 
     # unset GLUU_VERSION in order to prompt user-input
     prompter.settings["GLUU_VERSION"] = ""
@@ -42,7 +53,7 @@ def test_prompt_version(monkeypatch, prompter, given, expected):
 
 
 def test_prompt_license_accepted(monkeypatch, prompter):
-    monkeypatch.setattr("builtins.input", lambda x: "Y")
+    monkeypatch.setattr("click.confirm", lambda x: True)
 
     # unset GLUU_VERSION in order to prompt user-input
     prompter.settings["ACCEPT_GLUU_LICENSE"] = ""
@@ -50,11 +61,37 @@ def test_prompt_license_accepted(monkeypatch, prompter):
     assert prompter.settings["ACCEPT_GLUU_LICENSE"] == "Y"
 
 
-@pytest.mark.parametrize("given", ["", "N"])
-def test_prompt_license_rejected(monkeypatch, prompter, given):
-    monkeypatch.setattr("builtins.input", lambda x: given)
+def test_prompt_license_rejected(monkeypatch, prompter):
+    monkeypatch.setattr("click.confirm", lambda x: False)
 
     with pytest.raises(SystemExit):
         # unset GLUU_VERSION in order to prompt user-input
         prompter.settings["ACCEPT_GLUU_LICENSE"] = ""
         prompter.prompt_license()
+
+
+@pytest.mark.parametrize("given, expected", [
+    (1, "microk8s"),
+    (2, "minikube"),
+    (3, "eks"),
+    (4, "gke"),
+    (5, "aks"),
+    (6, "do"),
+    (7, "local"),
+    ("random", "microk8s"),
+])
+def test_prompt_arch(monkeypatch, prompter, given, expected):
+    monkeypatch.setattr("click.prompt", lambda x, default: given)
+    prompter.prompt_arch()
+    assert prompter.settings["DEPLOYMENT_ARCH"] == expected
+
+
+@pytest.mark.parametrize("given, expected", [
+    ("", "gluu"),
+    ("my-ns", "my-ns"),
+])
+def test_prompt_gluu_namespace(monkeypatch, prompter, given, expected):
+    monkeypatch.setattr("click.prompt", lambda x, default: given or expected)
+
+    prompter.prompt_gluu_namespace()
+    assert prompter.settings["GLUU_NAMESPACE"] == expected


### PR DESCRIPTION
The changeset are intended for replacing several `builtins.input` call found in `pygluu/kubernetes/prompt`.