### PR TITLE
integrate istio

### DIFF
--- a/pygluu/kubernetes/templates/README.md
+++ b/pygluu/kubernetes/templates/README.md
@@ -523,6 +523,15 @@
   255.255.255.255	broadcasthost
   ::1             localhost
   ```
+
+### Istio Integration
+To  use Istio as the service mesh for Cloud native gluu server deployment. Please follow the following instructions.
+- Setup [istio](https://istio.io/latest/docs/setup/platform-setup/) on your preffered kubernetes platform before installing Istio.
+- Use [istioctl](https://istio.io/latest/docs/setup/install/istioctl/) to install istio on your kubernetes cluster. Make sure to enable Kiali.
+- Once Istio is installed grab the istio-ingress gateway `loadBalancer` IP. For instructions on this, checkout [nginx-ingress](#nginx-ingress)  
+  for specifics depending on your platform.
+- Populate the parameter `global.nginxIp` with the IP.
+- Enable istio installation `global.istio.enabled` and deploy Gluu server
   
 ### Uninstalling the Chart
 
@@ -566,6 +575,7 @@ If during installation the release was not defined, release name is checked by r
 | `global.oxshibboleth.enabled`                      | Whether to allow installation of oxshibboleth chart                                                                              | `false`                             |
 | `global.key-rotation.enabled`                      | Allow key rotation                                                                                                               | `false`                             |
 | `global.cr-rotate.enabled`                         | Allow cache rotation deployment                                                                                                  | `false`                             |
+| `global.istio.enabled`                             | Allow Istio integration                                         | `false`                             |
 | `global.radius.enabled`                            | Enabled radius installation                                                                                                      | `false`                             |
 | `global.oxtrust.enabled`                           | Allow installation of oxtrust                                                                                                    |  `true`                             |
 | `global.nginx.enabled`                             | Allow installation of nginx. Should be allowed unless another nginx is being deployed                                            |  `true`                             |
@@ -659,6 +669,21 @@ global:
   cr-rotate:
     enabled: true
 ```
+
+## Integrate Istio
+
+### Install istio
+  - Initialize istio in your cluster using Helm V2
+    ` helm2 install install/kubernetes/helm/istio-init --name istio-init  --namespace istio-system`
+  - Make sure the initialization is complete
+    `kubectl -n istio-system wait --for=condition=complete job --all`
+  - Enable Istio auto injection in th namespace you are going to deploy Gluu Server
+    `kubectl label namespace <namespace-name> istio-injection=enabled`
+  - Install Istio using Helm V2
+    `helm2 install install/kubernetes/helm/istio --name istio --set gateways.istio-ingressgateway.sds.enabled=true --set sds.enabled=true --set values.global.mtls.enabled=true --set values.grafana.enabled=true --set values.sidecarInjectorWebhook.rewriteAppHTTPProbe=true --namespace istio-system `
+
+  - Before deploying Gluu server, make sure istio installation is enabled
+    `global.istio.enabled` is set to `true`
 
 ## Use Couchbase solely as the persistence layer
 

--- a/pygluu/kubernetes/templates/helm/gluu/Chart.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/Chart.yaml
@@ -65,3 +65,8 @@ dependencies:
     - name: persistence
       condition: global.persistence.enabled
       version: 1.0.0
+
+    - name: istio
+      condition: global.istio.enabled
+      version: 1.0.0
+      

--- a/pygluu/kubernetes/templates/helm/gluu/charts/casa/templates/casa-vs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/casa/templates/casa-vs.yaml
@@ -1,0 +1,25 @@
+# License terms and conditions for Gluu Cloud Native Edition:
+# https://www.apache.org/licenses/LICENSE-2.0
+{{- if .Values.global.istio.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  creationTimestamp: null
+  name: {{ include "istio.name" .}}-casa
+  namespace: default
+spec:
+  gateways:
+  - {{ .Release.Name }}-global-gtw
+  hosts:
+  - {{ .Values.global.domain }}
+  http:
+  - match:
+    - uri:
+        exact: /casa
+    route:
+    - destination:
+        host: casa.default.svc.cluster.local
+        port:
+          number: 8080
+      weight: 100
+{{- end }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/casa/templates/deployment.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/casa/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         APP_NAME: casa
         app: {{ include "casa.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.global.istio.enabled }}
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -42,8 +46,8 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - containerPort: 8080
-              protocol: TCP
+            - name: {{ .Values.service.name }}
+              containerPort: {{ .Values.service.port }}
           envFrom:
             - configMapRef: 
                 name: {{ include "casa.fullname" . }}
@@ -59,13 +63,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /casa/health-check
-              port: 8080
+              port: http-casa
             initialDelaySeconds: 25
             periodSeconds: 25
           readinessProbe:
             httpGet:
               path: /casa/health-check
-              port: 8080
+              port: http-casa
             initialDelaySeconds: 30
             periodSeconds: 30
           resources:

--- a/pygluu/kubernetes/templates/helm/gluu/charts/casa/templates/service.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/casa/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ports:
     - port: {{ .Values.service.port }}
-      name: casa
+      name: {{ .Values.service.name }}
   selector:
     app: {{ include "casa.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/casa/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/casa/values.yaml
@@ -24,6 +24,7 @@ securityContext: {}
 
 service:
   port: 8080
+  name: http-casa
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
@@ -49,16 +49,48 @@ data:
     name = "tls-certificate"
     namespace = {{ .Release.Namespace | quote }} 
 
+    # if istio is enabled
+    istio_ns = "istio-system"
+
+    # create cert in istio-sytem
+    def create_tls_in_istio(cert, key):
+
+        v1 = client.CoreV1Api()
+        try:
+            secret = v1.read_namespaced_secret(name, istio_ns)
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                print('secret/{} in ns/{} does not exist. Creating...'.format(
+                    name, istio_ns))
+                metadata = {
+                    'name': name,
+                    'namespace': istio_ns
+                }
+                data = {
+                    'tls.crt': cert,
+                    'tls.key' : key,
+                }
+                api_version = 'v1'
+                kind = 'Secret'
+                body = client.V1Secret(api_version, data , kind, metadata, 
+                    type='kubernetes.io/tls')
+                api_response = v1.create_namespaced_secret(istio_ns, body )
+                pprint(api_response)
+            else:
+                logging.exception(e)
+            return False
+        else:
+            print('tls-certificate already exists.')
+          
+
     # check if gluu secret exists
     def get_certs():
         if ( v1.read_namespaced_secret( 'gluu', namespace ) ):
             ssl_cert = v1.read_namespaced_secret( 'gluu', namespace ).data['ssl_cert']
             ssl_key = v1.read_namespaced_secret( "gluu", namespace ).data['ssl_key']
-            
-            print('ssl_cert / {} \n ssl_key: {}'.format(ssl_cert, ssl_key) )
 
         return ssl_cert, ssl_key
-
+    
     def create_tls(cert, key):
 
         v1 = client.CoreV1Api()
@@ -86,13 +118,16 @@ data:
                 logging.exception(e)
             return False
         else:
-            print('tls-certificate already exists as /{}'. format(
-                secret
-            ))
+            print('tls-certificate already exists.')
             
     def main():
         cert, key = get_certs()
         create_tls(cert, key)
+
+        # create or check cert if istio is enabled
+        {{- if .Values.global.istio.enabled }}
+        create_tls_in_istio(cert, key)
+        {{- end }}
 
     if __name__ == "__main__":
         main()

--- a/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
@@ -75,7 +75,6 @@ data:
                 body = client.V1Secret(api_version, data , kind, metadata, 
                     type='kubernetes.io/tls')
                 api_response = v1.create_namespaced_secret(istio_ns, body )
-                pprint(api_response)
             else:
                 logging.exception(e)
             return False
@@ -113,7 +112,6 @@ data:
                 body = client.V1Secret(api_version, data , kind, metadata, 
                     type='kubernetes.io/tls')
                 api_response = v1.create_namespaced_secret(namespace, body )
-                pprint(api_response)
             else:
                 logging.exception(e)
             return False

--- a/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/load-init-config.yml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/load-init-config.yml
@@ -35,6 +35,6 @@ spec:
         - configMapRef:
             name: {{ include "config.fullname" . }}-config-cm
         command: ["/bin/sh", "-c"]
-        args: ["tini -g -- /app/scripts/entrypoint.sh load && /usr/bin/python /scripts/tls_generator.py"]
+        args: ["tini -g -- /app/scripts/entrypoint.sh load && /usr/bin/python /scripts/tls_generator.py && curl -X POST http://localhost:15020/quitquitquit "]
       restartPolicy: Never
           

--- a/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/service.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/service.yaml
@@ -1,0 +1,18 @@
+# License terms and conditions:
+# https://www.gluu.org/license/enterprise-edition/
+apiVersion: v1
+kind: Service
+metadata:
+    name: {{ include "config.fullname" . }}
+    namespace: {{ .Values.global.namespace }}
+    labels:
+{{ include "config.labels" . | indent 6 }}
+spec:
+    ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+    selector:
+        app: {{ include "config.name" . }}-init-load
+    type: ClusterIP
+    

--- a/pygluu/kubernetes/templates/helm/gluu/charts/cr-rotate/templates/service.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/cr-rotate/templates/service.yaml
@@ -13,9 +13,7 @@ metadata:
 spec:
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+      name: {{ .Values.service.name }}
   selector:
     app: {{ include "cr-rotate.name" . }}
     release: {{ .Release.Name }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/cr-rotate/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/cr-rotate/values.yaml
@@ -10,7 +10,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
-  port: 8080
+  port: 8084
+  name: http-cr-rotate
 
 configMap:
   gluuContainerMetadata: kubernetes

--- a/pygluu/kubernetes/templates/helm/gluu/charts/istio/.helmignore
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/istio/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pygluu/kubernetes/templates/helm/gluu/charts/istio/Chart.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/istio/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: istio
+description: Istio integration files
+type: application
+version: 1.0.0
+appVersion: 4.1.0

--- a/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/_helpers.tpl
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "istio.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "istio.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "istio.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "istio.labels" -}}
+helm.sh/chart: {{ include "istio.chart" . }}
+{{ include "istio.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "istio.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "istio.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "istio.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "istio.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/casa-tp.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/casa-tp.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: {{ include "istio.name" . }}-casa-mtls
+spec:
+  host: casa.{{ .Release.Namespace }}.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/gateway.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/gateway.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: {{ .Release.Name }}-global-gtw
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  # oxtrust
+  - port:
+      number: 80
+      name: http-oxtrust
+      protocol: HTTP
+    hosts:
+      - {{ .Values.global.domain }}
+    tls:
+      httpsRedirect: true
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    hosts:
+      - {{ .Values.global.domain }}
+    tls:
+      mode: SIMPLE # enable https on this port
+      credentialName: tls-certificate # fetch cert from k8s secret
+  

--- a/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/oxauth-tp.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/oxauth-tp.yaml
@@ -1,0 +1,9 @@
+# apiVersion: networking.istio.io/v1alpha3
+# kind: DestinationRule
+# metadata:
+#   name: oxauth-istio-mtls
+# spec:
+#   host: oxauth.{{.Release.Namespace }}.svc.cluster.local
+#   trafficPolicy:
+#     tls:
+#       mode: ISTIO_MUTUAL

--- a/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/oxtrust-tp.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/istio/templates/oxtrust-tp.yaml
@@ -1,0 +1,11 @@
+# apiVersion: networking.istio.io/v1alpha3
+# kind: DestinationRule
+# metadata:
+#   name: {{ include "istio.name" . }}-oxtrust-mtls
+# spec:
+#   host: oxtrust.{{.Release.Namespace }}.svc.cluster.local
+#   trafficPolicy:
+#     tls:
+#       mode: ISTIO_MUTUAL
+
+

--- a/pygluu/kubernetes/templates/helm/gluu/charts/istio/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/istio/values.yaml
@@ -1,0 +1,4 @@
+# Default values for istio.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+

--- a/pygluu/kubernetes/templates/helm/gluu/charts/jackrabbit/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/jackrabbit/values.yaml
@@ -20,7 +20,7 @@ storage:
 
 #servicePorts values used in StatefulSet container
 ports:
-  jackrabbit:
+  http-jackrabbit:
     port: 8080
     targetPort: 8080
 # VolumeMounts for StatefulSet

--- a/pygluu/kubernetes/templates/helm/gluu/charts/key-rotation/templates/service.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/key-rotation/templates/service.yaml
@@ -10,9 +10,7 @@ metadata:
 spec:
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+      name: {{ .Values.service.name }}
   selector:
     app: {{ include "key-rotation.name" . }}
     release: {{ .Release.Name }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/key-rotation/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/key-rotation/values.yaml
@@ -13,6 +13,7 @@ fullnameOverride: ""
 
 service:
   port: 8080
+  name: http-k-rotation
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/pygluu/kubernetes/templates/helm/gluu/charts/opendj/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/opendj/values.yaml
@@ -36,16 +36,16 @@ persistence:
 
 #servicePorts values used in StatefulSet container
 ports:
-  ldaps:
+  tcp-ldaps:
     port: 1636
     targetPort: 1636
-  ldap:
+  tcp-ldap:
     port: 1389
     targetPort: 1389
-  replication:
+  tcp-repl:
     port: 8989
     targetPort: 8989
-  admin:
+  tcp-admin:
     port: 4444
     targetPort: 4444
 # VolumeMounts for StatefulSet

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxauth/templates/deployment.yml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxauth/templates/deployment.yml
@@ -18,6 +18,10 @@ spec:
       labels:
         APP_NAME: oxauth
         app: {{ include "oxauth.name" . }}
+      {{- if .Values.global.istio.enabled }}
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+      {{- end }}
     spec:
       containers:
       - name: {{ template "gluu.fullname" . }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxauth/templates/oxauth-vs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxauth/templates/oxauth-vs.yaml
@@ -87,7 +87,7 @@ spec:
   http:
   - match: 
     - uri:
-        exact: /oxauth
+        prefix: /oxauth
     route:
     - destination:
         host: oxauth.{{.Release.Namespace}}.svc.cluster.local

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxauth/templates/oxauth-vs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxauth/templates/oxauth-vs.yaml
@@ -1,0 +1,169 @@
+# License terms and conditions for Gluu Cloud Native Edition:
+# https://www.apache.org/licenses/LICENSE-2.0
+{{- if .Values.global.istio.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.name" . }}-openid-config
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw # can omit the namespace if gateway is in same namespace as virtual service.
+  http:
+  - match:
+    - uri:
+        prefix: /.well-known/openid-configuration
+    rewrite:
+      uri: /oxauth/.well-known/openid-configuration
+    route:
+      - destination:
+          host: oxauth.{{.Release.Namespace}}.svc.cluster.local
+          port:
+            number: 8080
+        weight: 100
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.name" . }}-uma2-config
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw 
+  http:
+  - match:    
+    - uri:
+        prefix: /.well-known/uma2-configuration
+    rewrite:
+      uri: /oxauth/restv1/uma2-configuration
+    route:
+      - destination:
+          host: oxauth.{{.Release.Namespace}}.svc.cluster.local
+          port:
+            number: 8080
+        weight: 100
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.name" . }}-webdiscovery
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw 
+  http:
+  - match: 
+    - uri:
+        prefix: /.well-known/simple-web-discovery
+    rewrite:
+      uri: /oxauth/.well-known/simple-web-discovery
+    route:
+    - destination:
+        host: oxauth.{{.Release.Namespace}}.svc.cluster.local
+        port:
+          number: 8080
+      weight: 100
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.name" . }}-gluu
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw 
+  http:
+  - match: 
+    - uri:
+        exact: /oxauth
+    route:
+    - destination:
+        host: oxauth.{{.Release.Namespace}}.svc.cluster.local
+        port:
+          number: 8080
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.name" . }}-webfinger
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw 
+  http:
+  - match: 
+    - uri:
+        prefix: /.well-known/webfinger
+    rewrite:
+      uri: /oxauth/.well-known/webfinger
+    route:
+    - destination:
+        host: oxauth.{{.Release.Namespace}}.svc.cluster.local
+        port:
+          number: 8080
+      weight: 100
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.name" . }}-u2f-config
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw 
+  http:
+  - match: 
+    - uri:
+        prefix: /.well-known/fido-configuration
+    rewrite:
+      uri: /oxauth/restv1/fido-configuration
+    route:
+    - destination:
+        host: oxauth.{{.Release.Namespace}}.svc.cluster.local
+        port:
+          number: 8080
+      weight: 100
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.name" . }}-fido2-configuration
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw 
+  http:
+  - match: 
+    - uri:
+        prefix: /.well-known/fido2-configuration
+    rewrite:
+      uri: /oxauth/restv1/fido2/configuration
+    route:
+    - destination:
+        host: oxauth.{{.Release.Namespace}}.svc.cluster.local
+        port:
+          number: 8080
+      weight: 100
+{{- end }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxauth/templates/service.yml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxauth/templates/service.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ports:
   - port: {{ .Values.ports.containerPort }}
-    name: {{ .Values.global.oxAuthServiceName }}
+    name: http-oxauth
   selector:
     app: {{ include "oxauth.name" . }} #oxauth
     

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxd-server/templates/deployment.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxd-server/templates/deployment.yaml
@@ -32,8 +32,10 @@ spec:
                 /app/scripts/entrypoint.sh
           {{- end }}
           ports:
-            - containerPort: 8444
-            - containerPort: 8443   
+            {{- range $key, $value := .Values.ports }}  
+            - containerPort: {{ $value.targetPort }}
+              name: {{ $value.name }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "oxd-server.fullname" . }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxd-server/templates/service.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxd-server/templates/service.yaml
@@ -10,9 +10,10 @@ metadata:
 {{ include "oxd-server.labels" . | indent 4 }}
 spec:
   ports:
-    - port: 8444
-      name: {{ include "oxd-server.name" . }}-admin-gui
-    - port: 8443
-      name: {{ include "oxd-server.name" . }}-app-connector
+  {{- range $key, $value := .Values.ports }}
+  - port: {{ $value.port }}
+    targetPort: {{ $value.targetPort }}
+    name: {{ $value.name }}
+  {{- end }}
   selector:
     app: {{ include "oxd-server.name" . }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxd-server/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxd-server/values.yaml
@@ -11,6 +11,14 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+ports:
+  - port: 8444
+    targetPort: 8444
+    name: tcp-admin-gui
+  - port: 8443
+    targetPort: 8443
+    name: tls-app-conn
+
 configmap:
   adminKeystorePassword: Passw0rd
   applicationKeystorePassword: Passw0rd

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/templates/deployment.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/templates/deployment.yaml
@@ -32,9 +32,7 @@ spec:
               /app/scripts/entrypoint.sh
         {{- end }}
         ports:
-          - name: http
-            containerPort: 8090
-            protocol: TCP
+          - containerPort: {{ .Values.service.port }}
         envFrom:
           - configMapRef:
               name: {{ include "oxpassport.name" . }}
@@ -54,14 +52,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /passport/token
-            port: http
+            port: {{ .Values.service.port }}
           initialDelaySeconds: 30
           periodSeconds: 30
           failureThreshold: 20
         readinessProbe:
           httpGet:
             path: /passport/token
-            port: http
+            port: {{ .Values.service.port }}
           initialDelaySeconds: 25
           periodSeconds: 25
           failureThreshold: 20

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/templates/passport-vs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/templates/passport-vs.yaml
@@ -15,8 +15,6 @@ spec:
   - match: 
     - uri:
         prefix: /passport
-    rewrite:
-      uri: identity
     route:
     - destination:
         host: oxpassport.{{.Release.Namespace}}.svc.cluster.local

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/templates/passport-vs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/templates/passport-vs.yaml
@@ -1,0 +1,26 @@
+# License terms and conditions for Gluu Cloud Native Edition:
+# https://www.apache.org/licenses/LICENSE-2.0
+{{- if .Values.global.istio.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.fullname" . }}-stateful-pp
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw 
+  http:
+  - match: 
+    - uri:
+        prefix: /passport
+    rewrite:
+      uri: identity
+    route:
+    - destination:
+        host: oxpassport.{{.Release.Namespace}}.svc.cluster.local
+        port:
+          number: 8090
+      weight: 100
+{{- end }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/templates/service.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/templates/service.yaml
@@ -10,9 +10,7 @@ metadata:
 spec:
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+      name: {{ .Values.service.name }}
   selector:
     app: {{ include "oxpassport.name" . }}
     release: {{ .Release.Name }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxpassport/values.yaml
@@ -13,6 +13,7 @@ fullnameOverride: ""
 
 service:
   port: 8090
+  name: http-oxpassport
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxshibboleth/templates/oxshibboleth-vs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxshibboleth/templates/oxshibboleth-vs.yaml
@@ -1,0 +1,26 @@
+# License terms and conditions for Gluu Cloud Native Edition:
+# https://www.apache.org/licenses/LICENSE-2.0
+{{- if .Values.global.istio.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.fullname" . }}-oxshibboleth
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+    - {{ .Values.global.domain }}
+  gateways:
+    - {{ .Release.Name }}-global-gtw
+  http:
+  - match:
+    - uri:
+        prefix: /idp
+    rewrite:
+      uri: /identity
+    route:
+    - destination:
+        host: oxshibboleth.{{ .Release.Namespace }}.svc.cluster.local
+        port:
+          number: 8080
+      weight: 100
+{{- end }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxshibboleth/templates/service.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxshibboleth/templates/service.yaml
@@ -10,9 +10,8 @@ metadata:
 spec:
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+      targetPort: {{ .Values.service.targetPort }}
+      name: {{ .Values.service.name }}
   selector:
     app: {{ include "oxshibboleth.name" . }}
     release: {{ .Release.Name }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxshibboleth/templates/statefulset.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxshibboleth/templates/statefulset.yaml
@@ -35,9 +35,8 @@ spec:
               /app/scripts/entrypoint.sh
         {{- end }}
         ports:
-          - name: http
-            containerPort: 8080
-            protocol: TCP
+          - name: {{ .Values.service.name }}
+            containerPort: {{ .Values.service.targetPort }}
         envFrom:
         - configMapRef:
             name: {{ include "oxshibboleth.fullname" . }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxshibboleth/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxshibboleth/values.yaml
@@ -13,6 +13,8 @@ fullnameOverride: ""
 
 service:
   port: 8080
+  targetPort: 8080
+  name: http-oxshibboleth
 
 resources: 
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/oxtrust-vs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/oxtrust-vs.yaml
@@ -15,6 +15,7 @@ spec:
   - match:
     - uri:
         exact: /
+    rewrite: /identity
     route:
     - destination:
         host: oxtrust.{{.Release.Namespace}}.svc.cluster.local

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/oxtrust-vs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/oxtrust-vs.yaml
@@ -1,0 +1,73 @@
+# License terms and conditions for Gluu Cloud Native Edition:
+# https://www.apache.org/licenses/LICENSE-2.0
+{{- if .Values.global.istio.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.fullname" . }}-base
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw
+  http:
+  - match:
+    - uri:
+        exact: /
+    route:
+    - destination:
+        host: oxtrust.{{.Release.Namespace}}.svc.cluster.local
+        port:
+          number: 8080
+      weight: 100
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.fullname" . }}-scim-config
+  namespace: {{ .Release.Namespace }}
+spec:
+  hosts:
+  - {{ .Values.global.domain }}
+  gateways:
+  - {{ .Release.Name }}-global-gtw # can omit the namespace if gateway is in same namespace as virtual service.
+  http:
+  - match:
+    - uri:
+        prefix: /.well-known/scim-configuration
+    rewrite:
+      uri: /identity/restv1/scim-configuration
+    route:
+      - destination:
+          host: oxtrust.{{.Release.Namespace}}.svc.cluster.local
+          port:
+            number: 8080
+        weight: 100
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "istio.name" .}}-oxtrust-stateful
+  namespace: {{ .Release.Namespace }}
+spec:
+  gateways:
+    - {{ .Release.Name }}-global-gtw
+  hosts:
+    - {{ .Values.global.domain }}
+  http:
+    - name: oxtrust-route
+      match:
+      - uri:
+          exact: /identity
+      route:
+      - destination:
+          host: oxtrust.{{ .Release.Namespace }}.svc.cluster.local
+          port:
+            number: 8080
+        weight: 100
+{{- end }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/oxtrust-vs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/oxtrust-vs.yaml
@@ -15,7 +15,8 @@ spec:
   - match:
     - uri:
         exact: /
-    rewrite: /identity
+    rewrite: 
+       uri: /identity
     route:
     - destination:
         host: oxtrust.{{.Release.Namespace}}.svc.cluster.local

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/service.yml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/service.yml
@@ -10,8 +10,7 @@ metadata:
 spec:
   ports:
   - port: {{ .Values.service.port }}
-    name: {{ template "oxtrust.fullname" . }}
+    name: http-oxtrust
   selector:
     app: {{ include "oxtrust.name" . }}
   clusterIP: {{ .Values.service.clusterIp }}
-    

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/statefulset.yml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/templates/statefulset.yml
@@ -19,6 +19,10 @@ spec:
       labels: 
         app: {{ include "oxtrust.name" . }}
         APP_NAME: oxtrust
+      {{- if .Values.global.istio.enabled }}
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+      {{- end }}
     spec:
       containers:
       - name: {{ include "oxtrust.name" . }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxtrust/values.yaml
@@ -20,8 +20,4 @@ limits:
   memory: 128Mi
 requests:
   memory: 300Mi
-
-#containerPOrt ot connect the container with
-containerPort: 8080
-
     

--- a/pygluu/kubernetes/templates/helm/gluu/charts/persistence/templates/jobs.yml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/persistence/templates/jobs.yml
@@ -18,6 +18,8 @@ spec:
       containers:
       - name: {{ include "persistence.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        command: [ "/bin/sh", "-c" ]
+        args: [ "tini -g -- /app/scripts/entrypoint.sh && curl -X POST http://localhost:15020/quitquitquit " ]
         envFrom:
         - configMapRef:
             name: {{ include "persistence.fullname" . }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/persistence/templates/service.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/persistence/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: {{ include "persistence.fullname" . }}
+    namespace: {{ .Values.global.namespace }}
+    labels:
+{{ include "persistence.labels" . | indent 6 }}
+spec:
+    ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+    selector:
+        app: {{ include "persistence.name" . }}  
+    type: ClusterIP
+    

--- a/pygluu/kubernetes/templates/helm/gluu/charts/radius/templates/deployment.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/radius/templates/deployment.yaml
@@ -32,13 +32,10 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-          - name: http
-            containerPort: 8080
-            protocol: TCP
-          - name: radius-auth
-            containerPort: 1812
-          - name: radius-ac
-            containerPort: 1813
+          {{- range $key, $value := .Values.service.ports }}
+          - containerPort: {{ $value.port }}
+            name: {{$key}}
+          {{- end }}
         envFrom:
           - configMapRef:
               name: {{ include "radius.fullname" . }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/radius/templates/service.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/radius/templates/service.yaml
@@ -11,8 +11,6 @@ spec:
   ports:
     {{- range $key, $value := .Values.service.ports }}
     - port: {{ $value.port }}
-      targetPort: http
-      protocol: TCP
       name: {{$key}}
     {{- end }}
   selector:

--- a/pygluu/kubernetes/templates/helm/gluu/charts/radius/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/radius/values.yaml
@@ -14,11 +14,11 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   ports:  
-    radius-authentication:
+    tcp-rad-auth:
       port: 1812
-    radius-accounting: 
+    tcp-rad-acc: 
       port: 1813
-    jetty-service:
+    http-jetty-svc:
       port: 8080
 
 configMap:

--- a/pygluu/kubernetes/templates/helm/gluu/values.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/values.yaml
@@ -112,6 +112,9 @@ global:
   cr-rotate:
     enabled: false  
 
+  istio:
+    enabled: false
+
 casa:
   image:
     repository: gluufederation/casa
@@ -137,7 +140,7 @@ config:
 
   image:
     repository: gluufederation/config-init
-    tag: 4.1.1_01
+    tag: 4.1.1_02
 
 cr-rotate:
   image:


### PR DESCRIPTION
### What does this PR
- Adds Istio service mesh to Gluu server cloud native deployment.

### Description of work done.
- Rename all the services' manifests to conform with istio service naming convention.
- Creates Istio gateway to give access Gluu server to the outside world.
- Create VirtualServices for service objects that instructs the gateway where to send the traffic of certain requests.

### Questions
- Currently having trouble with routing rules in VirtualServices. Everything else works fine but getting a blank screen with 503 error. Which means there is a route rule in that isn't redirecting traffic to the requested pod.
