### PR TITLE
Template Namespace used in oxd-server Helm chart.

### DIFF
--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxd-server/templates/networkpolicy.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxd-server/templates/networkpolicy.yaml
@@ -1,7 +1,7 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  namespace: gluu
+  namespace: {{ .Release.Namespace }}
   name: oxd-server-policy
 spec:
   policyTypes:

--- a/pygluu/kubernetes/templates/oxd-server/base/networkpolicy.yaml
+++ b/pygluu/kubernetes/templates/oxd-server/base/networkpolicy.yaml
@@ -1,7 +1,6 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  namespace: gluu
   name: oxd-server-policy
 spec:
   policyTypes:


### PR DESCRIPTION
### What does this PR do?
- It fixes the error one gets trying to deploy Gluu server using helm to a different `namespace` other than `gluu` ns if gluu ns is not manually created.
Handles #139 

### Description of task done
- Use template namespace for `NetworkPolicy` object of `oxd-server` 

