### PR TITLE
Remove printing of certs if they exist

### DIFF
--- a/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/configmaps.yaml
@@ -143,10 +143,6 @@ data:
             else:
                 logging.exception(e)
             return False
-        else:
-            print('tls-certificate already exists as /{}'. format(
-                secret
-            ))
             
     def main():
         cert, key = get_certs()


### PR DESCRIPTION
### What does this PR do?
- Removes print of cert if it already exists in the cluster.