### PR TITLE
CLI: show image prompt after selecting upgrade version

### DIFF
--- a/pygluu/kubernetes/terminal/upgrade.py
+++ b/pygluu/kubernetes/terminal/upgrade.py
@@ -11,6 +11,7 @@ https://www.apache.org/licenses/LICENSE-2.0
 import click
 
 from pygluu.kubernetes.helpers import get_supported_versions
+from pygluu.kubernetes.terminal.images import PromptImages
 
 
 class PromptUpgrade:
@@ -35,4 +36,7 @@ class PromptUpgrade:
 
         image_names_and_tags = versions.get(self.settings.get("GLUU_UPGRADE_TARGET_VERSION"), {})
         self.settings.update(image_names_and_tags)
-        self.settings.store_data()
+
+        # reset this config to force image prompt
+        self.settings.set("EDIT_IMAGE_NAMES_TAGS", "")
+        PromptImages(self.settings).prompt_image_name_tag()

--- a/tests/terminal/test_upgrade.py
+++ b/tests/terminal/test_upgrade.py
@@ -9,7 +9,11 @@ def test_upgrade_version(monkeypatch, settings, given, expected):
     from pygluu.kubernetes.terminal.upgrade import PromptUpgrade
 
     monkeypatch.setattr("click.prompt", lambda x, default: given or expected)
+    monkeypatch.setattr(
+        "pygluu.kubernetes.terminal.images.PromptImages.prompt_image_name_tag",
+        lambda cls: None,
+    )
 
-    prompt = PromptUpgrade(settings)
-    prompt.prompt_upgrade()
+    PromptUpgrade(settings).prompt_upgrade()
     assert settings.get("GLUU_UPGRADE_TARGET_VERSION") == expected
+    assert settings.get("EDIT_IMAGE_NAMES_TAGS") == ""


### PR DESCRIPTION
The commit changeset tries to address issue found in #226 with the following behavior:

1. After selecting upgrade version, the `EDIT_IMAGE_NAMES_TAGS` is resetted to empty string
1. A prompt to enter custom image name and/or tag is presented to users. With this approach, users has a method to use custom image (either by keeping their old images or upgraded to newer images)

For illustration:

1. The `settings.json` has `LDAP_IMAGE_NAME=acme/opendj` and `LDAP_IMAGE_TAG=4.2.1_01.acme1`
1. `GLUU_UPGRADE_TARGET_VERSION` upgraded to `4.3` by running `pygluu-kubernetes upgrade` command
1. The upgrade images are saved to `settings.json` (`LDAP_IMAGE_NAME=gluufederation/opendj` and `LDAP_IMAGE_TAG=4.3.0_01`)
1. Given image prompt is presented
    - users will be able to use their old custom image (`LDAP_IMAGE_NAME=acme/opendj` and `LDAP_IMAGE_TAG=4.2.1_01.acme1`)
    - or use newer custom image (`LDAP_IMAGE_NAME=acme/opendj-4.3` and `LDAP_IMAGE_TAG=4.3.0_01.acme1`)