### PR TITLE
feat(validate-settings): Add settings validation before installing

### DIFF
--- a/pygluu/kubernetes/create.py
+++ b/pygluu/kubernetes/create.py
@@ -64,9 +64,15 @@ def main():
         parser.print_help()
         return
     copy_templates()
+    settings = SettingsHandler()
+    settings.validate()
+    if not settings.validate():
+        for error in settings.errors:
+            logger.error(error)
+        sys.exit()
+
     prompts = Prompt()
     prompts.prompt()
-    settings = SettingsHandler()
 
     timeout = 120
     if args.subparser_name == "install-no-wait":

--- a/pygluu/kubernetes/gui/templates/preinstall.html
+++ b/pygluu/kubernetes/gui/templates/preinstall.html
@@ -7,17 +7,37 @@
 		        <h4 class="alert-heading">{{ title }}</h4>
 			    <p class="mb-0">Get started with new settings or upload existing settings.</p>
 			    <hr>
-			    {% if setting_exist %}
-					<p class="mb-0 font-weight-lighter text-danger">Attention! Existing installation settings are detected, do backup if you plan to create / upload settings, it overwrites current settings</p>
+			    {% if settings.is_exist() %}
+					<p class="mb-0 font-weight-lighter text-warning">Attention! Existing installation settings are detected, do backup if you plan to create / upload settings, it overwrites current settings</p>
+				{% endif %}
+				{% if error_count > 0 %}
+					<div class="alert alert-danger" role="alert">
+					  	<h4 class="alert-heading">{{ error_count }} Errors Occurred!</h4>
+  						<p>Your settings.json is invalid, please resolve the errors before continue.</p>
+
+					</div>
+					<ul class="list-group">
+						{% for error in settings.errors[:10] %}
+							<li class="list-group-item">{{ error }}</li>
+						{% endfor %}
+						{% for error in settings.errors[10:] %}
+							<li class="list-group-item collapse multi-collapse">{{ error }}</li>
+						{% endfor %}
+					</ul>
+					{% if error_count > 10 %}
+						<div class="clearfix">
+							<button class="btn btn-outline-primary btn-block" type="button" data-toggle="collapse" data-target=".multi-collapse" aria-expanded="false" aria-controls="multiCollapseExample2">Show More</button>
+						</div>
+					{% endif %}
 				{% endif %}
 		    </div>
 		    <div class="text-center">
 			    <a href="{{ url_for('wizard.new') }}" class="btn btn-primary">Start with new settings</a>
 				<div id="formUpload" class="d-inline-block">
 					<input id="uploadSetting" type="file" class="btn btn-success" name="upload-settings" style="position: absolute !important; width: 1px; height: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px); white-space: nowrap;">
-					<label class="btn btn-info mb-0" for="uploadSetting">Upload existing settings</label>
+					<label class="btn btn-info mb-0" for="uploadSetting">Upload settings</label>
 		        </div>
-			    {% if setting_exist %}
+			    {% if settings.is_exist() and error_count == 0 %}
 			        <a href="{{ url_for('wizard.agreement') }}" class="btn btn-light">Continue with current settings</a>
 			    {% endif %}
 		    </div>
@@ -56,10 +76,12 @@
 
 	        if(data.success){
 	            window.location.href = data.redirect_url
-	        }
+	        }else{
+				window.location.reload()
+			}
 	    })
 	    .catch((error) => {
-	        console.log("error happened")
+	        window.location.reload()
 	    });
 	};
 

--- a/pygluu/kubernetes/gui/views/main.py
+++ b/pygluu/kubernetes/gui/views/main.py
@@ -22,6 +22,15 @@ logger = get_logger("gluu-gui        ")
 main_blueprint = Blueprint("main", __name__, template_folder="templates")
 
 
+@main_blueprint.before_request
+def initialize():
+    """
+    Do settings setting.json validation
+    """
+    if not request.endpoint == "main.index":
+        gluu_settings.db.validate()
+
+
 @main_blueprint.route("/")
 def index():
     return render_template("index.html")
@@ -38,9 +47,13 @@ def install():
             return redirect(url_for("main.index"))
 
     session["finish_endpoint"] = request.endpoint
+    session["install_method"] = "kustomize"
+
     return render_template("preinstall.html",
                            title="Setup install Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/install-no-wait", methods=["GET", "POST"])
@@ -56,7 +69,9 @@ def install_no_wait():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup install Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/install-ldap-backup", methods=["GET", "POST"])
@@ -72,7 +87,9 @@ def install_ldap_backup():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup install Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/install-kubedb", methods=["GET", "POST"])
@@ -88,7 +105,9 @@ def install_kubedb():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup install Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/install-gg-dbmode", methods=["GET", "POST"])
@@ -106,7 +125,9 @@ def install_gg_dbmode():
     if validating_gg_settings():
         return render_template("preinstall.html",
                                title="Setup install Settings",
-                               setting_exist=gluu_settings.db.is_exist())
+                               setting_exist=gluu_settings.db.is_exist(),
+                               settings=gluu_settings.db,
+                               error_count=len(gluu_settings.db.errors))
     else:
         return redirect(url_for("wizard.gluu_gateway"))
 
@@ -124,7 +145,9 @@ def install_couchbase():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup install Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/install-couchbase-backup", methods=["GET", "POST"])
@@ -140,7 +163,9 @@ def install_couchbase_backup():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup install Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/helm-install-gg-dbmode", methods=["GET", "POST"])
@@ -156,7 +181,9 @@ def helm_install_gg_dbmode():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup install Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/helm-install", methods=["GET", "POST"])
@@ -172,7 +199,9 @@ def helm_install():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup install Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/helm-install-gluu", methods=["GET", "POST"])
@@ -188,7 +217,9 @@ def helm_install_gluu():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup install Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/generate-settings", methods=["GET", "POST"])
@@ -218,7 +249,9 @@ def upgrade():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup upgrade Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/restore", methods=["GET", "POST"])
@@ -234,7 +267,9 @@ def restore():
     session["finish_endpoint"] = request.endpoint
     return render_template("preinstall.html",
                            title="Setup restore Settings",
-                           setting_exist=gluu_settings.db.is_exist())
+                           setting_exist=gluu_settings.db.is_exist(),
+                           settings=gluu_settings.db,
+                           error_count=len(gluu_settings.db.errors))
 
 
 @main_blueprint.route("/uninstall", methods=["POST"])
@@ -252,12 +287,15 @@ def uninstall():
             else:
                 return render_template("preinstall.html",
                                        title="Setup Uninstall Settings",
-                                       setting_exist=settings_exist)
+                                       setting_exist=settings_exist,
+                                       settings=gluu_settings.db,
+                                       error_count=len(gluu_settings.db.errors))
 
         if request.form["confirm_params"] == "Y":
             gluu_settings.db.set("CONFIRM_PARAMS", "Y")
             target = session["installer_target"]
             return render_template("installation.html", target=target)
+
 
 def allowed_file(filename):
     return '.' in filename and \
@@ -276,7 +314,11 @@ def upload_file():
 
         if file and allowed_file(file.filename):
             filename = secure_filename(file.filename)
-            file.save(os.path.join('./', filename))
+            file.save(os.path.join('./settings.json'))
+            gluu_settings.db.validate()
+            if not gluu_settings.db.is_valid:
+                return jsonify(
+                    {"success": False, 'message': 'Invalid settings'})
             redirect_url = get_wizard_step()
             return jsonify({"success": True,
                             'message': 'File settings has been uploaded',

--- a/settings_schema.json
+++ b/settings_schema.json
@@ -1,0 +1,1277 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties" : false,
+  "properties": {
+    "ACCEPT_CN_LICENSE": { "$ref": "#/definitions/yes-no-string" },
+    "CN_VERSION": { "type": "string" },
+    "TEST_ENVIRONMENT": { "$ref": "#/definitions/yes-no-string" },
+    "CN_UPGRADE_TARGET_VERSION": { "type": "string" },
+    "CN_HELM_RELEASE_NAME": { "type": "string" },
+    "NGINX_INGRESS_RELEASE_NAME": { "type": "string" },
+    "NGINX_INGRESS_NAMESPACE": { "type": "string" },
+    "INSTALL_GLUU_GATEWAY": { "$ref": "#/definitions/yes-no-string" },
+    "POSTGRES_NAMESPACE": { "type": "string" },
+    "KONG_NAMESPACE": { "type": "string" },
+    "GLUU_GATEWAY_UI_NAMESPACE": { "type": "string" },
+    "KONG_PG_USER": { "type": "string" },
+    "KONG_PG_PASSWORD": { "type": "string" },
+    "GLUU_GATEWAY_UI_PG_USER": { "type": "string" },
+    "GLUU_GATEWAY_UI_PG_PASSWORD": { "type": "string" },
+    "KONG_DATABASE": { "type": "string" },
+    "GLUU_GATEWAY_UI_DATABASE": { "type": "string" },
+    "POSTGRES_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "POSTGRES_URL": { "type": "string" },
+    "KONG_HELM_RELEASE_NAME": { "type": "string" },
+    "GLUU_GATEWAY_UI_HELM_RELEASE_NAME": { "type": "string" },
+    "USE_ISTIO": { "$ref": "#/definitions/yes-no-string" },
+    "USE_ISTIO_INGRESS": { "$ref": "#/definitions/yes-no-string" },
+    "ISTIO_SYSTEM_NAMESPACE": { "type": "string" },
+    "NODES_IPS": { "type": "array" },
+    "NODES_ZONES": { "type": "array" },
+    "NODES_NAMES": { "type": "array" },
+    "NODE_SSH_KEY": { "type": "string" },
+    "HOST_EXT_IP": { "type": "string", "format": "ipv4" },
+    "VERIFY_EXT_IP": { "$ref": "#/definitions/yes-no-string" },
+    "AWS_LB_TYPE": { "type": "string", "enum": ["clb", "nlb", "alb", ""] },
+    "USE_ARN": { "$ref": "#/definitions/yes-no-string"},
+    "VPC_CIDR": { "type": "string" },
+    "ARN_AWS_IAM": { "type": "string" },
+    "LB_ADD": { "type": "string" },
+    "REDIS_URL": { "type": "string" },
+    "REDIS_TYPE": { "type": "string" },
+    "REDIS_PW": { "type": "string" },
+    "REDIS_USE_SSL": { "type": "string", "enum": ["true", "false"] },
+    "REDIS_SSL_TRUSTSTORE": { "type": "string" },
+    "REDIS_SENTINEL_GROUP": { "type": "string" },
+    "REDIS_MASTER_NODES": { "$ref": "#/definitions/emptiable-number" },
+    "REDIS_NODES_PER_MASTER": { "$ref": "#/definitions/emptiable-number" },
+    "REDIS_NAMESPACE": { "type": "string" },
+    "INSTALL_REDIS": { "$ref": "#/definitions/yes-no-string" },
+    "INSTALL_JACKRABBIT": { "$ref": "#/definitions/yes-no-string" },
+    "JACKRABBIT_STORAGE_SIZE": { "type": "string" },
+    "JACKRABBIT_URL": { "type": "string" },
+    "JACKRABBIT_ADMIN_ID": { "type": "string" },
+    "JACKRABBIT_ADMIN_PASSWORD": { "$ref": "#/definitions/password" },
+    "JACKRABBIT_CLUSTER": { "type": "string" },
+    "JACKRABBIT_PG_USER": { "type": "string" },
+    "JACKRABBIT_PG_PASSWORD": { "$ref": "#/definitions/password" },
+    "JACKRABBIT_DATABASE": { "type": "string" },
+    "DEPLOYMENT_ARCH": { "type": "string", "enum": ["microk8s", "minikube", "eks", "gke", "aks", "do", "local", ""] },
+    "PERSISTENCE_BACKEND": { "type": "string", "enum": ["ldap", "couchbase", "hybrid", ""] },
+    "INSTALL_COUCHBASE": { "$ref": "#/definitions/yes-no-string" },
+    "COUCHBASE_NAMESPACE": { "type": "string" },
+    "COUCHBASE_VOLUME_TYPE": { "type": "string" },
+    "COUCHBASE_CLUSTER_NAME": { "type": "string" },
+    "COUCHBASE_URL": { "type": "string" },
+    "COUCHBASE_USER": { "type": "string" },
+    "COUCHBASE_SUPERUSER": { "type": "string" },
+    "COUCHBASE_PASSWORD": { "type": "string" },
+    "COUCHBASE_SUPERUSER_PASSWORD": { "type": "string" },
+    "COUCHBASE_CRT": { "type": "string" },
+    "COUCHBASE_CN": { "type": "string" },
+    "COUCHBASE_INDEX_NUM_REPLICA": { "type": "string" },
+    "COUCHBASE_SUBJECT_ALT_NAME": { "$ref": "#/definitions/emptiable-array" },
+    "COUCHBASE_CLUSTER_FILE_OVERRIDE": { "$ref": "#/definitions/yes-no-string" },
+    "COUCHBASE_USE_LOW_RESOURCES": { "$ref": "#/definitions/yes-no-string"},
+    "COUCHBASE_DATA_NODES": { "type": "string" },
+    "COUCHBASE_QUERY_NODES": { "type": "string" },
+    "COUCHBASE_INDEX_NODES": { "type": "string" },
+    "COUCHBASE_SEARCH_EVENTING_ANALYTICS_NODES": { "type": "string" },
+    "COUCHBASE_GENERAL_STORAGE": { "type": "string" },
+    "COUCHBASE_DATA_STORAGE": { "type": "string" },
+    "COUCHBASE_INDEX_STORAGE": { "type": "string" },
+    "COUCHBASE_QUERY_STORAGE": { "type": "string" },
+    "COUCHBASE_ANALYTICS_STORAGE": { "type": "string" },
+    "COUCHBASE_INCR_BACKUP_SCHEDULE": { "type": "string" },
+    "COUCHBASE_FULL_BACKUP_SCHEDULE": { "type": "string" },
+    "COUCHBASE_BACKUP_RETENTION_TIME": { "type": "string" },
+    "COUCHBASE_BACKUP_STORAGE_SIZE": { "type": "string" },
+    "LDAP_BACKUP_SCHEDULE": { "type": "string" },
+    "NUMBER_OF_EXPECTED_USERS": { "$ref": "#/definitions/emptiable-number" },
+    "EXPECTED_TRANSACTIONS_PER_SEC": { "type": "string" },
+    "USING_CODE_FLOW": { "$ref": "#/definitions/yes-no-string" },
+    "USING_SCIM_FLOW": { "$ref": "#/definitions/yes-no-string" },
+    "USING_RESOURCE_OWNER_PASSWORD_CRED_GRANT_FLOW": { "$ref": "#/definitions/yes-no-string" },
+    "DEPLOY_MULTI_CLUSTER": { "type": "string" },
+    "HYBRID_LDAP_HELD_DATA": { "type": "string", "enum": ["", "default", "user", "site", "cache", "token"] },
+    "LDAP_JACKRABBIT_VOLUME": { "type": "string" },
+    "APP_VOLUME_TYPE": { "$ref": "#/definitions/emptiable-number" },
+    "LDAP_STATIC_VOLUME_ID": { "type": "string" },
+    "LDAP_STATIC_DISK_URI": { "type": "string" },
+    "CN_CACHE_TYPE": { "type": "string", "enum": ["IN_MEMORY", "REDIS", "NATIVE_PERSISTENCE", ""]},
+    "CN_NAMESPACE": { "type": "string" },
+    "CN_FQDN": { "$ref": "#/definitions/fqdn-pattern" },
+    "COUNTRY_CODE": { "type": "string" },
+    "STATE": { "type": "string" },
+    "EMAIL": { "$ref": "#/definitions/email-format" },
+    "CITY": { "type": "string" },
+    "ORG_NAME": { "type": "string" },
+    "GMAIL_ACCOUNT": { "$ref": "#/definitions/email-format" },
+    "GOOGLE_NODE_HOME_DIR": { "type": "string" },
+    "IS_CN_FQDN_REGISTERED": { "$ref": "#/definitions/yes-no-string" },
+    "LDAP_PW": { "$ref": "#/definitions/password" },
+    "ADMIN_PW": { "$ref": "#/definitions/password" },
+    "CLIENT_API_APPLICATION_KEYSTORE_CN": { "type": "string" },
+    "CLIENT_API_ADMIN_KEYSTORE_CN": { "type": "string" },
+    "LDAP_STORAGE_SIZE": { "type": "string" },
+    "AUTH_SERVER_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "OXTRUST_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "LDAP_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "OXSHIBBOLETH_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "OXPASSPORT_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "CLIENT_API_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "CASA_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "RADIUS_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "FIDO2_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "SCIM_REPLICAS": { "$ref": "#/definitions/emptiable-number" },
+    "ENABLE_CONFIG_API": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_OXTRUST_API": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_OXTRUST_TEST_MODE": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_CACHE_REFRESH": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_CLIENT_API": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_FIDO2": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_SCIM": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_RADIUS": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_OXPASSPORT": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_OXSHIBBOLETH": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_CASA": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_AUTH_SERVER_KEY_ROTATE": { "$ref": "#/definitions/yes-no-string" },
+    "ENABLE_OXTRUST_API_BOOLEAN": { "$ref": "#/definitions/emptiable-boolean-string" },
+    "ENABLE_OXTRUST_TEST_MODE_BOOLEAN": { "$ref": "#/definitions/emptiable-boolean-string" },
+    "ENABLE_RADIUS_BOOLEAN": { "$ref": "#/definitions/emptiable-boolean-string" },
+    "ENABLE_OXPASSPORT_BOOLEAN": { "$ref": "#/definitions/emptiable-boolean-string" },
+    "ENABLE_CASA_BOOLEAN": { "$ref": "#/definitions/emptiable-boolean-string" },
+    "ENABLE_SAML_BOOLEAN": { "$ref": "#/definitions/emptiable-boolean-string" },
+    "ENABLED_SERVICES_LIST": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "config",
+          "auth-server",
+          "oxtrust",
+          "persistence",
+          "jackrabbit",
+          "gluu-gateway-ui",
+          "cr-rotate",
+          "auth-server-key-rotation",
+          "radius",
+          "oxpassport",
+          "oxshibboleth",
+          "casa",
+          "fido2",
+          "scim",
+          "client-api",
+          "ldap",
+          "update-lb-ip"
+        ]
+      },
+      "uniqueItems": true },
+    "AUTH_SERVER_KEYS_LIFE": { "$ref": "#/definitions/emptiable-number"},
+    "EDIT_IMAGE_NAMES_TAGS": { "$ref": "#/definitions/yes-no-string" },
+    "CASA_IMAGE_NAME": { "type": "string" },
+    "CASA_IMAGE_TAG": { "type": "string" },
+    "CONFIG_IMAGE_NAME": { "type": "string" },
+    "CONFIG_IMAGE_TAG": { "type": "string" },
+    "CACHE_REFRESH_ROTATE_IMAGE_NAME": { "type": "string" },
+    "CACHE_REFRESH_ROTATE_IMAGE_TAG": { "type": "string" },
+    "CERT_MANAGER_IMAGE_NAME": { "type": "string" },
+    "CERT_MANAGER_IMAGE_TAG": { "type": "string" },
+    "LDAP_IMAGE_NAME": { "type": "string" },
+    "LDAP_IMAGE_TAG": { "type": "string" },
+    "JACKRABBIT_IMAGE_NAME": { "type": "string" },
+    "JACKRABBIT_IMAGE_TAG": { "type": "string" },
+    "AUTH_SERVER_IMAGE_NAME": { "type": "string" },
+    "AUTH_SERVER_IMAGE_TAG": { "type": "string" },
+    "FIDO2_IMAGE_NAME": { "type": "string" },
+    "FIDO2_IMAGE_TAG": { "type": "string" },
+    "SCIM_IMAGE_NAME": { "type": "string" },
+    "SCIM_IMAGE_TAG": { "type": "string" },
+    "CLIENT_API_IMAGE_NAME": { "type": "string" },
+    "CLIENT_API_IMAGE_TAG": { "type": "string" },
+    "OXPASSPORT_IMAGE_NAME": { "type": "string" },
+    "OXPASSPORT_IMAGE_TAG": { "type": "string" },
+    "OXSHIBBOLETH_IMAGE_NAME": { "type": "string" },
+    "OXSHIBBOLETH_IMAGE_TAG": { "type": "string" },
+    "OXTRUST_IMAGE_NAME": { "type": "string" },
+    "OXTRUST_IMAGE_TAG": { "type": "string" },
+    "PERSISTENCE_IMAGE_NAME": { "type": "string" },
+    "PERSISTENCE_IMAGE_TAG": { "type": "string" },
+    "RADIUS_IMAGE_NAME": { "type": "string" },
+    "RADIUS_IMAGE_TAG": { "type": "string" },
+    "GLUU_GATEWAY_IMAGE_NAME": { "type": "string" },
+    "GLUU_GATEWAY_IMAGE_TAG": { "type": "string" },
+    "GLUU_GATEWAY_UI_IMAGE_NAME": { "type": "string" },
+    "GLUU_GATEWAY_UI_IMAGE_TAG": { "type": "string" },
+    "UPGRADE_IMAGE_NAME": { "type": "string" },
+    "UPGRADE_IMAGE_TAG": { "type": "string" },
+    "CONFIRM_PARAMS": { "$ref": "#/definitions/yes-no-string" },
+    "EXPECTED_TRANSACTION_PER_SEC": { "type": "string" },
+    "CLIENT_API_SERVER_REPLICAS": { "$ref": "#/definitions/emptiable-number" }
+  },
+  "allOf": [
+    { "$ref": "#/definitions/cache-refresh-enabled"},
+    { "$ref": "#/definitions/auth-server-key-rotate-enabled"},
+    { "$ref": "#/definitions/radius-enabled" },
+    { "$ref": "#/definitions/oxpassport-enabled" },
+    { "$ref": "#/definitions/oxshibboleth-enabled" },
+    { "$ref": "#/definitions/casa-enabled" },
+    { "$ref": "#/definitions/fido2-enabled" },
+    { "$ref": "#/definitions/scim-enabled" },
+    { "$ref": "#/definitions/client-api-enabled" },
+    { "$ref": "#/definitions/oxtrust-api-enabled" },
+    { "$ref": "#/definitions/oxtrust-test-mode-enabled"},
+    { "$ref": "#/definitions/gluu-gateway-installed" },
+    { "$ref": "#/definitions/install-jackrabbit-yes" },
+    { "$ref": "#/definitions/install-jackrabbit-no" },
+    { "$ref": "#/definitions/jackrabbit-cluster-enable" },
+    { "$ref": "#/definitions/istio-ingress-yes" },
+    { "$ref": "#/definitions/istio-yes" },
+    { "$ref": "#/definitions/test-environment" },
+    { "$ref": "#/definitions/network-aws" },
+    { "$ref": "#/definitions/use-arn-yes" },
+    { "$ref": "#/definitions/deployment-arch-gke" },
+    { "$ref": "#/definitions/persistence-backend-ldap" },
+    { "$ref": "#/definitions/persistence-backend-hybrid"},
+    { "$ref": "#/definitions/microk8s-architecture" },
+    { "$ref": "#/definitions/minikube-architecture" },
+    { "$ref": "#/definitions/eks-architecture" },
+    { "$ref": "#/definitions/gke-architecture" },
+    { "$ref": "#/definitions/aks-architecture" },
+    { "$ref": "#/definitions/do-architecture" },
+    { "$ref": "#/definitions/local-architecture" },
+    { "$ref": "#/definitions/ldap-volume-identifier" },
+    { "$ref": "#/definitions/ldap-disk-uris" },
+    { "$ref": "#/definitions/ldap-jackrabbit-volume-on-aks" },
+    { "$ref": "#/definitions/ldap-jackrabbit-volume-on-eks" },
+    { "$ref": "#/definitions/ldap-jackrabbit-volume-on-gke" },
+    { "$ref": "#/definitions/ldap-storage" },
+    { "$ref": "#/definitions/couchbase-multi-cluster" },
+    { "$ref": "#/definitions/couchbase-persistence-backend" },
+    { "$ref": "#/definitions/install-couchbase-yes" },
+    { "$ref": "#/definitions/install-couchbase-no" },
+    { "$ref": "#/definitions/couchbase-not-use-low-resource" },
+    { "$ref": "#/definitions/cache-type-redis" },
+    { "$ref": "#/definitions/install-redis-yes" },
+    { "$ref": "#/definitions/install-redis-no" },
+    { "$ref": "#/definitions/backup-hybrid-couchbase" },
+    { "$ref": "#/definitions/backup-ldap" }
+  ],
+  "definitions": {
+    "yes-no-string": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": ["Y", "N"]
+        },
+        {
+          "type": "string",
+          "maxLength": 0
+        }
+      ]
+    },
+    "emptiable-number": {
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 1
+        },
+        {
+          "type": "string",
+          "maxLength": 0
+        }
+      ]
+    },
+    "emptiable-array": {
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "string",
+          "maxLength": 0
+        }
+      ]
+    },
+    "emptiable-boolean-string": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": ["true", "false", ""]
+        },
+        {
+          "type": "string",
+          "maxLength": 0
+        }
+      ]
+    },
+    "string-cannot-empty": {
+      "type": "string",
+      "minLength": 1,
+      "errors": {
+        "minLength":  "Field cannot be empty"
+      }
+    },
+    "password": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*\\W)[a-zA-Z0-9\\S]{6,}$",
+          "minLength": 6,
+          "errors": {
+            "minLength": "Password minimum 6 character",
+            "pattern": "Password does not meet requirements. The password must contain one digit, one uppercase letter, one lower case letter and one symbol"
+          }
+        },
+        {
+          "type": "string",
+          "maxLength": 0
+        }
+      ]
+    },
+    "password-pattern": {
+      "type": "string",
+      "pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*\\W)[a-zA-Z0-9\\S]{6,}$",
+      "minLength": 6,
+      "errors": {
+        "minLength": "Password minimum 6 character",
+        "pattern": "Password does not meet requirements. The password must contain one digit, one uppercase letter, one lower case letter and one symbol"
+      }
+    },
+    "email-format": {
+      "type": "string",
+      "format": "email"
+    },
+    "fqdn-pattern": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.){2,}([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]){2,}$",
+          "errors": {
+            "pattern": "Setting not FQDN structured. Please enter a FQDN with the format demoexample.gluu.org"
+          }
+        },
+        {
+          "type": "string",
+          "maxLength": 0
+        }
+      ]
+    },
+    "cache-refresh-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_CACHE_REFRESH": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["cr-rotate"] },
+            "errors": {
+              "contains": "cr-rotate key not found"
+            }
+          }
+        },
+        "required": ["ENABLED_SERVICES_LIST"]
+      }
+    },
+    "auth-server-key-rotate-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_AUTH_SERVER_KEY_ROTATE": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "AUTH_SERVER_KEYS_LIFE": { "type": "number", "minimum": 48 },
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["auth-server-key-rotation"] },
+            "errors": {
+              "contains": "auth-server-key-rotation key not found"
+            }
+          }
+        },
+        "required": ["ENABLED_SERVICES_LIST", "AUTH_SERVER_KEYS_LIFE"]
+      }
+    },
+    "radius-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_RADIUS": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLE_RADIUS_BOOLEAN": { "const": "true" },
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["radius"] },
+            "errors": {
+              "contains": "radius key not found"
+            }
+          }
+        },
+        "required": ["ENABLE_RADIUS_BOOLEAN", "ENABLED_SERVICES_LIST"]
+      }
+    },
+    "oxpassport-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_OXPASSPORT": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLE_OXPASSPORT_BOOLEAN": { "const": "true" },
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["oxpassport"] },
+            "errors": {
+              "contains": "oxpassport key not found"
+            }
+          }
+        },
+        "required": ["ENABLE_OXPASSPORT_BOOLEAN", "ENABLED_SERVICES_LIST"]
+      }
+    },
+    "oxshibboleth-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_OXSHIBBOLETH": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLE_SAML_BOOLEAN": { "const": "true" },
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["oxshibboleth"] },
+            "errors": {
+              "contains": "oxshibboleth key not found"
+            }
+          }
+        },
+        "required": ["ENABLE_SAML_BOOLEAN", "ENABLED_SERVICES_LIST"]
+      }
+    },
+    "casa-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_CASA": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLE_CASA_BOOLEAN": { "const": "true" },
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["casa"] },
+            "errors": {
+              "contains": "casa key not found"
+            }
+          },
+          "ENABLE_CLIENT_API": { "const": "Y" }
+        },
+        "required": ["ENABLE_CASA_BOOLEAN", "ENABLE_CLIENT_API", "ENABLED_SERVICES_LIST"]
+      }
+    },
+    "fido2-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_FIDO2": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["fido2"] },
+            "errors": {
+              "contains": "fido2 key not found"
+            }
+          }
+        },
+        "required": ["ENABLED_SERVICES_LIST"]
+      }
+    },
+    "scim-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_SCIM": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["scim"] },
+            "errors": {
+              "contains": "scim key not found"
+            }
+          }
+        },
+        "required": ["ENABLED_SERVICES_LIST"]
+      }
+    },
+    "client-api-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_CLIENT_API": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["client-api"] },
+            "errors": {
+              "contains": "client-api key not found"
+            }
+          },
+          "CLIENT_API_APPLICATION_KEYSTORE_CN": { "type": "string", "minLength": 3 },
+          "CLIENT_API_ADMIN_KEYSTORE_CN": { "type": "string", "minLength": 3 }
+        },
+        "required": ["CLIENT_API_APPLICATION_KEYSTORE_CN", "CLIENT_API_ADMIN_KEYSTORE_CN", "ENABLED_SERVICES_LIST"]
+      }
+    },
+    "oxtrust-api-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_OXTRUST_API": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLE_OXTRUST_API_BOOLEAN": { "const": "true" },
+          "ENABLE_OXTRUST_TEST_MODE": { "type": "string", "enum": ["Y", "N"] }
+        },
+        "required": ["ENABLE_OXTRUST_API_BOOLEAN", "ENABLE_OXTRUST_TEST_MODE"]
+      }
+    },
+    "oxtrust-test-mode-enabled": {
+      "if": {
+        "properties": {
+          "ENABLE_OXTRUST_TEST_MODE": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLE_OXTRUST_TEST_MODE_BOOLEAN": { "const": "true" }
+        },
+        "required": ["ENABLE_OXTRUST_TEST_MODE_BOOLEAN"]
+      }
+    },
+    "gluu-gateway-installed": {
+      "if": {
+        "properties": { "INSTALL_GLUU_GATEWAY": { "const": "Y" } }
+      },
+      "then": {
+        "properties": {
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["gluu-gateway-ui"] },
+            "errors": {
+              "contains": "gluu-gateway-ui key not found"
+            }
+          },
+          "ENABLE_CLIENT_API": { "const": "Y" },
+          "POSTGRES_NAMESPACE": { "$ref": "#/definitions/string-cannot-empty" },
+          "POSTGRES_REPLICAS": { "type":"number", "minimum": 1  },
+          "POSTGRES_URL": { "$ref": "#/definitions/string-cannot-empty" },
+          "KONG_NAMESPACE": { "$ref": "#/definitions/string-cannot-empty" },
+          "KONG_DATABASE": { "$ref": "#/definitions/string-cannot-empty" },
+          "KONG_PG_USER": { "$ref": "#/definitions/string-cannot-empty" },
+          "KONG_PG_PASSWORD": { "$ref": "#/definitions/password-pattern" },
+          "GLUU_GATEWAY_UI_NAMESPACE": { "$ref": "#/definitions/string-cannot-empty" },
+          "GLUU_GATEWAY_UI_DATABASE": { "$ref": "#/definitions/string-cannot-empty" },
+          "GLUU_GATEWAY_UI_PG_USER": { "$ref": "#/definitions/string-cannot-empty" },
+          "GLUU_GATEWAY_UI_PG_PASSWORD": { "$ref": "#/definitions/password-pattern" }
+
+        },
+        "required": [
+          "ENABLED_SERVICES_LIST",
+          "ENABLE_CLIENT_API",
+          "POSTGRES_NAMESPACE",
+          "POSTGRES_REPLICAS",
+          "POSTGRES_URL",
+          "KONG_NAMESPACE",
+          "KONG_DATABASE",
+          "KONG_PG_USER",
+          "KONG_PG_PASSWORD",
+          "GLUU_GATEWAY_UI_NAMESPACE",
+          "GLUU_GATEWAY_UI_DATABASE",
+          "GLUU_GATEWAY_UI_PG_USER",
+          "GLUU_GATEWAY_UI_PG_PASSWORD"
+        ]
+      }
+    },
+    "install-jackrabbit-yes": {
+      "if": {
+        "properties": {
+          "INSTALL_JACKRABBIT": { "const": "Y"}
+        }
+      },
+      "then": {
+        "properties": {
+          "JACKRABBIT_STORAGE_SIZE": { "type": "string", "minLength": 3, "maxLength": 3},
+          "JACKRABBIT_URL": { "type": "string", "minLength": 3, "format": "uri" },
+          "JACKRABBIT_ADMIN_ID": { "type":  "string", "minLength": 3 },
+          "JACKRABBIT_ADMIN_PASSWORD": { "$ref": "#/definitions/password-pattern" },
+          "JACKRABBIT_CLUSTER": { "type": "string", "enum": ["Y", "N"] }
+        },
+        "required": [
+          "JACKRABBIT_STORAGE_SIZE",
+          "JACKRABBIT_URL",
+          "JACKRABBIT_ADMIN_ID",
+          "JACKRABBIT_ADMIN_PASSWORD",
+          "JACKRABBIT_CLUSTER"
+        ]
+      }
+    },
+    "install-jackrabbit-no": {
+      "if": {
+        "properties": {
+          "INSTALL_JACKRABBIT": { "const": "N"}
+        }
+      },
+      "then": {
+        "properties": {
+          "JACKRABBIT_URL": { "type": "string", "minLength": 3, "format": "uri" },
+          "JACKRABBIT_ADMIN_ID": { "$ref": "#/definitions/string-cannot-empty" },
+          "JACKRABBIT_ADMIN_PASSWORD": { "$ref": "#/definitions/password-pattern" },
+          "JACKRABBIT_CLUSTER": { "type": "string", "enum": ["Y", "N"] }
+        },
+        "required": [
+          "JACKRABBIT_URL",
+          "JACKRABBIT_ADMIN_ID",
+          "JACKRABBIT_ADMIN_PASSWORD",
+          "JACKRABBIT_CLUSTER"
+        ]
+      }
+    },
+    "jackrabbit-cluster-enable": {
+      "if": {
+        "properties": {
+          "JACKRABBIT_CLUSTER": { "const": "Y"}
+        }
+      },
+      "then": {
+        "properties": {
+          "POSTGRES_NAMESPACE": { "$ref": "#/definitions/string-cannot-empty" },
+          "POSTGRES_REPLICAS": { "type":"number", "minimum": 1  },
+          "POSTGRES_URL": { "$ref": "#/definitions/string-cannot-empty" },
+          "JACKRABBIT_PG_USER": { "$ref": "#/definitions/string-cannot-empty" },
+          "JACKRABBIT_PG_PASSWORD": { "$ref": "#/definitions/password-pattern" },
+          "JACKRABBIT_DATABASE": { "$ref": "#/definitions/string-cannot-empty" }
+        },
+        "required": [
+            "POSTGRES_NAMESPACE",
+            "POSTGRES_REPLICAS",
+            "POSTGRES_URL",
+            "JACKRABBIT_PG_USER",
+            "JACKRABBIT_PG_PASSWORD",
+            "JACKRABBIT_DATABASE"
+          ]
+
+      }
+    },
+    "istio-ingress-yes": {
+      "if": {
+        "properties": {
+          "USE_ISTIO_INGRESS": { "const":  "Y"}
+        }
+      },
+      "then": {
+        "properties": {
+          "USE_ISTIO": { "const": "Y"},
+          "LB_ADD": { "$ref": "#/definitions/string-cannot-empty" }
+        },
+        "required": ["USE_ISTIO", "LB_ADD"]
+      }
+    },
+    "istio-yes": {
+      "if": {
+        "properties": {
+          "USE_ISTIO": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "ISTIO_SYSTEM_NAMESPACE": { "$ref": "#/definitions/string-cannot-empty" }
+        },
+        "required": ["ISTIO_SYSTEM_NAMESPACE"]
+      }
+    },
+    "test-environment": {
+      "if": {
+        "properties": {
+          "DEPLOYMENT_ARCH": { "enum": ["aks", "eks", "gke", "do", "local"] }
+        }
+      },
+      "then": {
+        "properties": {
+          "TEST_ENVIRONMENT": { "type": "string", "enum":  ["Y", "N"] },
+          "NODE_SSH_KEY": { "$ref": "#/definitions/string-cannot-empty" }
+        },
+        "required": ["TEST_ENVIRONMENT", "NODE_SSH_KEY"]
+      }
+    },
+    "network-aws": {
+      "if": {
+        "properties": {
+          "DEPLOYMENT_ARCH": { "const": "eks" },
+          "USE_ISTIO_INGRESS": { "const": "N" }
+        }
+      },
+      "then": {
+        "properties": {
+          "AWS_LB_TYPE": { "type": "string", "enum":  ["clb", "nlb", "alb"] },
+          "USE_ARN": { "type":  "string", "enum": ["Y", "N"] }
+        },
+        "required": ["AWS_LB_TYPE", "USE_ARN"]
+      }
+    },
+    "use-arn-yes": {
+      "if": {
+        "properties": {
+          "USE_ARN": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "AWS_VPC_CIDR": { "$ref": "#/definitions/string-cannot-empty" },
+          "ARN_AWS_IAM": { "$ref": "#/definitions/string-cannot-empty" }
+        },
+        "required": ["AWS_VPC_CIDR", "ARN_AWS_IAM"]
+      }
+    },
+    "deployment-arch-gke": {
+      "if": {
+        "properties": {
+          "DEPLOYMENT_ARCH": { "const": "gke" }
+        }
+      },
+      "then": {
+        "properties": {
+          "GMAIL_ACCOUNT": { "type": "string", "format": "email", "minLength": 3 }
+        },
+        "required": ["GOOGLE_NODE_HOME_DIR"]
+      }
+    },
+    "persistence-backend-ldap": {
+      "if": {
+        "properties": {
+          "PERSISTENCE_BACKEND": { "const": "ldap"}
+        }
+      },
+      "then": {
+        "properties": {
+          "ENABLED_SERVICES_LIST": {
+            "contains": { "enum" : ["ldap"] },
+            "errors": {
+              "contains": "ldap key not found"
+            }
+          }
+        }
+      }
+    },
+    "persistence-backend-hybrid": {
+      "if": {
+        "properties": {
+          "PERSISTENCE_BACKEND": { "const": "hybrid"}
+        }
+      },
+      "then": {
+        "properties": {
+          "HYBRID_LDAP_HELD_DATA": {
+            "type": "string",
+            "enum" : ["default", "user", "site", "cache", "token", "session"]
+          }
+        }
+      }
+    },
+    "microk8s-architecture": {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "microk8s" },
+              "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"] },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          },
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "microk8s" },
+              "INSTALL_JACKRABBIT": { "const": "Y" },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "APP_VOLUME_TYPE": { "const": 1 }
+        }
+      }
+    },
+    "minikube-architecture": {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "minikube" },
+              "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"] },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          },
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "minikube" },
+              "INSTALL_JACKRABBIT": { "const": "Y" },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "APP_VOLUME_TYPE": { "const": 2 }
+        }
+      }
+    },
+    "eks-architecture": {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "eks" },
+              "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"] },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          },
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "eks" },
+              "INSTALL_JACKRABBIT": { "const": "Y" },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "APP_VOLUME_TYPE": { "type": "number", "enum": [6, 7, 8] }
+        }
+      }
+    },
+    "gke-architecture": {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "gke" },
+              "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"] },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          },
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "gke" },
+              "INSTALL_JACKRABBIT": { "const": "Y" },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "APP_VOLUME_TYPE": { "type": "number", "enum": [11, 12, 13] }
+        }
+      }
+    },
+    "aks-architecture": {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "aks" },
+              "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"] },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          },
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "aks" },
+              "INSTALL_JACKRABBIT": { "const": "Y" },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "APP_VOLUME_TYPE": { "type": "number", "enum": [16, 17, 18] }
+        }
+      }
+    },
+    "do-architecture": {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "do" },
+              "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"] },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          },
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "do" },
+              "INSTALL_JACKRABBIT": { "const": "Y" },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "APP_VOLUME_TYPE": { "type": "number", "enum": [21, 22, 23] }
+        }
+      }
+    },
+    "local-architecture": {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "local" },
+              "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"] },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          },
+          {
+            "properties": {
+              "DEPLOYMENT_ARCH": { "const": "local" },
+              "INSTALL_JACKRABBIT": { "const": "Y" },
+              "APP_VOLUME_TYPE": { "not" : {"const": "" } }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "APP_VOLUME_TYPE": { "type": "number", "enum": [26] }
+        }
+      }
+    },
+    "ldap-volume-identifier": {
+      "if": {
+        "properties": {
+          "APP_VOLUME_TYPE": { "type": "number", "enum": [8, 13] },
+          "PERSISTENCE_BACKEND": { "type": "string", "enum": ["hybrid", "ldap"]},
+          "INSTALL_JACKRABBIT": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "LDAP_STATIC_VOLUME_ID": { "type": "string", "minLength": 1 }
+        },
+        "required": ["LDAP_STATIC_VOLUME_ID"]
+      }
+    },
+    "ldap-disk-uris": {
+      "if": {
+        "properties": {
+          "APP_VOLUME_TYPE": { "const": 18 },
+          "PERSISTENCE_BACKEND": { "type": "string", "enum": ["hybrid", "ldap"]},
+          "INSTALL_JACKRABBIT": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "LDAP_STATIC_DISK_URI": { "type": "string", "minLength": 1 }
+        },
+        "required": ["LDAP_STATIC_DISK_URI"]
+      }
+    },
+    "ldap-jackrabbit-volume-on-aks": {
+      "if": {
+        "properties": {
+          "DEPLOYMENT_ARCH": { "const": "aks" },
+          "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"]},
+          "INSTALL_JACKRABBIT": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "LDAP_JACKRABBIT_VOLUME": {
+            "type": "string",
+            "enum": ["Standard_LRS", "Premium_LRS", "StandardSSD_LRS", "UltraSSD_LRS"] }
+        },
+        "required": ["LDAP_JACKRABBIT_VOLUME"]
+      }
+    },
+    "ldap-jackrabbit-volume-on-eks": {
+      "if": {
+        "properties": {
+          "DEPLOYMENT_ARCH": { "const": "eks" },
+          "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"]},
+          "INSTALL_JACKRABBIT": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "LDAP_JACKRABBIT_VOLUME": {
+            "type": "string",
+            "enum": ["gp2", "io1", "st1", "sc1"] }
+        },
+        "required": ["LDAP_JACKRABBIT_VOLUME"]
+      }
+    },
+    "ldap-jackrabbit-volume-on-gke": {
+      "if": {
+        "properties": {
+          "DEPLOYMENT_ARCH": { "const": "gke" },
+          "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"]},
+          "INSTALL_JACKRABBIT": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "LDAP_JACKRABBIT_VOLUME": {
+            "type": "string",
+            "enum": ["pd-standard", "pd-ssd"] }
+        },
+        "required": ["LDAP_JACKRABBIT_VOLUME"]
+      }
+    },
+    "ldap-storage": {
+      "if": {
+        "properties": {
+          "PERSISTENCE_BACKEND": { "enum": ["hybrid", "ldap"]}
+        }
+      },
+      "then": {
+        "properties": {
+          "LDAP_STORAGE_SIZE": { "$ref": "#/definitions/string-cannot-empty" }
+        },
+        "required": ["LDAP_STORAGE_SIZE"]
+      }
+    },
+    "couchbase-multi-cluster": {
+      "if": {
+        "properties": {
+          "PERSISTENCE_BACKEND": { "enum": ["hybrid", "couchbase"]},
+          "DEPLOYMENT_ARCH": { "enum": ["aks", "eks", "gke", "do", "local"]}
+        }
+      },
+      "then": {
+        "properties": {
+          "DEPLOY_MULTI_CLUSTER": {
+            "type": "string",
+            "enum": ["Y", "N"]
+          }
+        },
+        "required": ["DEPLOY_MULTI_CLUSTER"]
+      }
+    },
+    "couchbase-persistence-backend": {
+      "if": {
+        "properties": {
+          "PERSISTENCE_BACKEND": { "enum": ["hybrid", "couchbase"]}
+        }
+      },
+      "then": {
+        "properties": {
+          "DEPLOYMENT_ARCH": {
+            "type": "string",
+            "enum": ["microk8s", "minikube", "aks", "eks", "gke", "do", "local"]
+          },
+          "CN_NAMESPACE": { "$ref": "#/definitions/string-cannot-empty" },
+          "HOST_EXT_IP": { "type": "string", "format": "ipv4", "minLength": 7 },
+          "INSTALL_COUCHBASE": { "type": "string", "enum": ["Y", "N"] }
+        },
+        "required": ["INSTALL_COUCHBASE"]
+      }
+    },
+    "install-couchbase": {
+      "properties": {
+        "COUCHBASE_CLUSTER_FILE_OVERRIDE": {"type": "string", "enum": ["Y", "N"] },
+        "COUCHBASE_USE_LOW_RESOURCES": {"type": "string", "enum": ["Y", "N"] },
+        "COUCHBASE_NAMESPACE": { "$ref": "#/definitions/string-cannot-empty" },
+        "COUCHBASE_CLUSTER_NAME": { "$ref": "#/definitions/string-cannot-empty" },
+        "COUCHBASE_URL": { "$ref": "#/definitions/string-cannot-empty" },
+        "COUCHBASE_INDEX_NUM_REPLICA": { "$ref": "#/definitions/string-cannot-empty" },
+        "COUCHBASE_SUPERUSER": { "$ref": "#/definitions/string-cannot-empty" },
+        "COUCHBASE_SUPERUSER_PASSWORD": { "$ref": "#/definitions/password-pattern" },
+        "COUCHBASE_USER": { "$ref": "#/definitions/string-cannot-empty" },
+        "COUCHBASE_PASSWORD": { "$ref": "#/definitions/password-pattern" }
+      },
+      "required": [
+        "COUCHBASE_CLUSTER_FILE_OVERRIDE",
+        "COUCHBASE_USE_LOW_RESOURCES",
+        "COUCHBASE_NAMESPACE",
+        "COUCHBASE_CLUSTER_NAME",
+        "COUCHBASE_URL",
+        "COUCHBASE_INDEX_NUM_REPLICA",
+        "COUCHBASE_SUPERUSER",
+        "COUCHBASE_SUPERUSER_PASSWORD",
+        "COUCHBASE_USER",
+        "COUCHBASE_PASSWORD"
+      ]
+    },
+    "install-couchbase-yes": {
+      "if": {
+        "properties": {
+          "INSTALL_COUCHBASE": { "const": "Y" }
+        }
+      },
+      "then": {
+        "$ref": "#/definitions/install-couchbase"
+      }
+    },
+    "install-couchbase-no": {
+      "if": {
+        "properties": {
+          "INSTALL_COUCHBASE": { "const": "N" }
+        }
+      },
+      "then": {
+        "properties": {
+          "COUCHBASE_CRT": { "$ref": "#/definitions/string-cannot-empty" }
+        },
+        "$ref": "#/definitions/install-couchbase",
+        "required": ["COUCHBASE_CRT"]
+      }
+    },
+    "couchbase-not-use-low-resource": {
+      "if": {
+        "properties": {
+          "COUCHBASE_USE_LOW_RESOURCES": { "const": "N" },
+          "COUCHBASE_CLUSTER_FILE_OVERRIDE": { "enum": ["N", "Y"]}
+        }
+      },
+      "then": {
+        "properties": {
+          "NUMBER_OF_EXPECTED_USERS": { "type": "number", "minimum": 1 },
+          "USING_RESOURCE_OWNER_PASSWORD_CRED_GRANT_FLOW": { "type": "string", "enum": ["Y", "N"] },
+          "USING_CODE_FLOW": { "type": "string", "enum": ["Y", "N"] },
+          "USING_SCIM_FLOW": { "type": "string", "enum": ["Y", "N"] },
+          "COUCHBASE_DATA_NODES": { "$ref": "#/definitions/emptiable-number" },
+          "COUCHBASE_INDEX_NODES": { "$ref": "#/definitions/emptiable-number" },
+          "COUCHBASE_QUERY_NODES": { "$ref": "#/definitions/emptiable-number" },
+          "COUCHBASE_SEARCH_EVENTING_ANALYTICS_NODES": { "$ref": "#/definitions/emptiable-number" },
+          "COUCHBASE_GENERAL_STORAGE": { "$ref": "#/definitions/emptiable-number" },
+          "COUCHBASE_INDEX_STORAGE": { "$ref": "#/definitions/emptiable-number" },
+          "COUCHBASE_QUERY_STORAGE": { "$ref": "#/definitions/emptiable-number" },
+          "COUCHBASE_ANALYTICS_STORAGE": { "$ref": "#/definitions/emptiable-number" },
+          "COUCHBASE_VOLUME_TYPE": {
+            "type": "string",
+            "enum": [
+              "pd-standard",
+              "pd-ssd",
+              "gp2",
+              "io1",
+              "st1",
+              "sc1",
+              "Standard_LRS",
+              "Premium_LRS",
+              "StandardSSD_LRS",
+              "UltraSSD_LRS"
+            ]
+          }
+        },
+        "required": [
+          "NUMBER_OF_EXPECTED_USERS",
+          "USING_RESOURCE_OWNER_PASSWORD_CRED_GRANT_FLOW",
+          "USING_CODE_FLOW",
+          "USING_SCIM_FLOW",
+          "COUCHBASE_DATA_NODES",
+          "COUCHBASE_INDEX_NODES",
+          "COUCHBASE_QUERY_NODES",
+          "COUCHBASE_SEARCH_EVENTING_ANALYTICS_NODES",
+          "COUCHBASE_GENERAL_STORAGE",
+          "COUCHBASE_INDEX_STORAGE",
+          "COUCHBASE_QUERY_STORAGE",
+          "COUCHBASE_ANALYTICS_STORAGE",
+          "COUCHBASE_VOLUME_TYPE"
+        ]
+      }
+    },
+    "cache-type-redis": {
+      "if": {
+        "properties": {
+          "CN_CACHE_TYPE": { "const": "REDIS" }
+        }
+      },
+      "then": {
+        "properties": {
+          "REDIS_TYPE": { "type": "string", "enum": ["STANDALONE", "CLUSTER"] },
+          "INSTALL_REDIS": { "type": "string", "enum": ["Y", "N"] },
+          "REDIS_URL": { "$ref": "#/definitions/string-cannot-empty" }
+        }
+      },
+      "required": ["REDIS_TYPE", "INSTALL_REDIS", "REDIS_URL"]
+    },
+    "install-redis-yes": {
+      "if": {
+        "properties": {
+          "INSTALL_REDIS": { "const": "Y" }
+        }
+      },
+      "then": {
+        "properties": {
+          "REDIS_MASTER_NODES": { "type": "number", "minimum": 3 },
+          "REDIS_NODES_PER_MASTER": {  "type": "number", "minimum": 1 },
+          "REDIS_NAMESPACE": { "type": "string", "minimum": 1 }
+        }
+      },
+      "required": ["REDIS_MASTER_NODES", "REDIS_NODES_PER_MASTER", "REDIS_NAMESPACE"]
+    },
+    "install-redis-no": {
+      "if": {
+        "properties": {
+          "INSTALL_REDIS": { "const": "N" }
+        }
+      },
+      "then": {
+        "properties": {
+          "REDIS_PW": { "type": "string", "minLength": 6 }
+        }
+      },
+      "required": ["REDIS_PW"]
+    },
+    "backup-hybrid-couchbase": {
+      "if": {
+        "properties": {
+          "DEPLOYMENT_ARCH": { "enum": ["aks", "eks", "gke", "do", "local"] },
+          "PERSISTENCE_BACKEND": { "enum": ["hybrid", "couchbase"] }
+        }
+      },
+      "then": {
+        "properties": {
+          "COUCHBASE_INCR_BACKUP_SCHEDULE": { "$ref": "#/definitions/string-cannot-empty" },
+          "COUCHBASE_FULL_BACKUP_SCHEDULE": { "$ref": "#/definitions/string-cannot-empty" },
+          "COUCHBASE_BACKUP_RETENTION_TIME": { "$ref": "#/definitions/string-cannot-empty" },
+          "COUCHBASE_BACKUP_STORAGE_SIZE": { "$ref": "#/definitions/string-cannot-empty" }
+        }
+      },
+      "required": [
+        "COUCHBASE_INCR_BACKUP_SCHEDULE",
+        "COUCHBASE_FULL_BACKUP_SCHEDULE",
+        "COUCHBASE_BACKUP_RETENTION_TIME",
+        "COUCHBASE_BACKUP_STORAGE_SIZE"
+      ]
+    },
+    "backup-ldap": {
+      "if": {
+        "properties": {
+          "DEPLOYMENT_ARCH": { "enum": ["aks", "eks", "gke", "do", "local"] },
+          "PERSISTENCE_BACKEND": { "const": "ldap" }
+        }
+      },
+      "then": {
+        "properties": {
+          "LDAP_BACKUP_SCHEDULE": { "$ref": "#/definitions/string-cannot-empty" }
+        }
+      },
+      "required": [
+        "LDAP_BACKUP_SCHEDULE"
+      ]
+    }
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
         "Flask-SocketIO >= 4.3.1",
         "Pygtail >= 0.11.1",
         "gunicorn >= 20.0.4",
-        "gevent >= 20.9.0"
+        "gevent >= 20.9.0",
+        "jsonschema >= 3.2.0",
     ],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
### What is this PR?
Adding detail validation for settings.json see #164

### How it works?
Using json schema to validate `settings.json` file, The validation will run before populating `settings.json` and running install. this validation runs on both `gui` and `tui` installation methods. 

the schema will be covering validation for :
- **input/variable types** for string, number, enum (e.g [Y, N]), password pattern, fqdn pattern and array.
- **input/variable dependencies** for example when `INSTALL_GLUU_GATEWAY` set to `Y` then the other variables like `KONG_NAMESPACE`, `KONG_DATABASE`, `KONG_PG_USER` etc is required or cannot be empty.

