### PR TITLE
fix(settings-validation): typo, and remove duplicate properties 

### DIFF
--- a/pygluu/kubernetes/gui/forms/replicas.py
+++ b/pygluu/kubernetes/gui/forms/replicas.py
@@ -15,7 +15,7 @@ class ReplicasForm(FlaskForm):
         ldap_replicas (integer|optional|default: 1)
         oxshibboleth_replicas (integer|optional|default: 1)
         oxpassport_replicas (integer|optional|default: 1)
-        client_api_server_replicas (integer|optional|default: 1)
+        client_api_replicas (integer|optional|default: 1)
         casa_replicas (integer|optional|default: 1)
         radius_replicas (integer|optional|default: 1)
     """
@@ -30,7 +30,7 @@ class ReplicasForm(FlaskForm):
     oxpassport_replicas = IntegerField("Number of oxPassport replicas",
                                        default=1,
                                        validators=[Optional()])
-    client_api_server_replicas = IntegerField("Number of client-api replicas",
+    client_api_replicas = IntegerField("Number of client-api replicas",
                                        default=1,
                                        validators=[Optional()])
     casa_replicas = IntegerField("Number of Casa replicas", default=1, validators=[Optional()])

--- a/pygluu/kubernetes/gui/views/wizard.py
+++ b/pygluu/kubernetes/gui/views/wizard.py
@@ -1135,7 +1135,7 @@ def replicas():
     if gluu_settings.db.get("ENABLE_OXPASSPORT") == "N":
         del form.oxpassport_replicas
     if gluu_settings.db.get("ENABLE_CLIENT_API") == "N":
-        del form.client_api_server_replicas
+        del form.client_api_replicas
     if gluu_settings.db.get("ENABLE_CASA") == "N":
         del form.casa_replicas
     if gluu_settings.db.get("ENABLE_RADIUS") == "N":

--- a/settings_schema.json
+++ b/settings_schema.json
@@ -206,9 +206,7 @@
     "GLUU_GATEWAY_UI_IMAGE_TAG": { "type": "string" },
     "UPGRADE_IMAGE_NAME": { "type": "string" },
     "UPGRADE_IMAGE_TAG": { "type": "string" },
-    "CONFIRM_PARAMS": { "$ref": "#/definitions/yes-no-string" },
-    "EXPECTED_TRANSACTIONS_PER_SEC": { "type": "string" },
-    "CLIENT_API_SERVER_REPLICAS": { "$ref": "#/definitions/emptiable-number" }
+    "CONFIRM_PARAMS": { "$ref": "#/definitions/yes-no-string" }
   },
   "allOf": [
     { "$ref": "#/definitions/cache-refresh-enabled"},


### PR DESCRIPTION
## What is in the PR?
- renaming typo or confusing field name on gui replicas form
- removing duplicate properties on json schema file