### PR TITLE
Fix cloud-native installer to allow spaces in paths

### DIFF
--- a/pygluu/kubernetes/kustomize.py
+++ b/pygluu/kubernetes/kustomize.py
@@ -578,16 +578,16 @@ class Kustomize(object):
 
             if app == "ldap":
                 if self.settings.get("PERSISTENCE_BACKEND") in ("hybrid", "ldap"):
-                    command = self.kubectl + " kustomize " + str(
-                        self.ldap_kustomize_yaml_directory.resolve())
+                    command = self.kubectl + " kustomize " "\"" + str(
+                        self.ldap_kustomize_yaml_directory.resolve()) + "\""
                     self.build_manifest(app, kustomization_file, command,
                                         "LDAP_IMAGE_NAME", "LDAP_IMAGE_TAG", app_file)
                     self.adjust_ldap_jackrabbit(app_file)
                     self.remove_resources(app_file, "StatefulSet")
 
             if app == "jackrabbit" and self.settings.get("INSTALL_JACKRABBIT") == "Y":
-                command = self.kubectl + " kustomize " + str(
-                    self.jcr_kustomize_yaml_directory.resolve())
+                command = self.kubectl + " kustomize " "\"" + str(
+                    self.jcr_kustomize_yaml_directory.resolve()) + "\""
                 self.build_manifest(app, kustomization_file, command,
                                     "JACKRABBIT_IMAGE_NAME", "JACKRABBIT_IMAGE_TAG", app_file)
                 self.adjust_ldap_jackrabbit(app_file)


### PR DESCRIPTION
This PR solves [this issue](https://github.com/GluuFederation/cloud-native-edition/issues/269) that was raised.

**Explanation**

On a Mac (or 'Nix system) running any any pygluu-kubernetes command like `install` or `restore` in a folder path with a name that has spaces in it returns as `ERROR - Error: specify one path to a kustomization directory`

I was able to reproduce this error more than thrice.
<img width="865" alt="Screenshot 2021-03-09 at 18 34 10" src="https://user-images.githubusercontent.com/17182751/110542706-75d65880-813a-11eb-849e-3f73eee874af.png">

<img width="1231" alt="Screenshot 2021-03-09 at 19 09 51" src="https://user-images.githubusercontent.com/17182751/110543530-7fac8b80-813b-11eb-98f2-db297248091a.png">


**Fix**

Tried debugging absolute path but found out it wasn't the issue. I had to follow the error / trace to determine that what caused it was in kustomize.py from either line 138, 1614, 591 or 935 in the `kustomize_it` function. I used both print statements and pdb to try and figure out where exactly the issue was. 
<img width="1180" alt="Screenshot 2021-03-09 at 19 20 44" src="https://user-images.githubusercontent.com/17182751/110543154-001ebc80-813b-11eb-8b2e-42c66ab2462f.png">


I then figured out the issue was that the path being called after the kustomize command was being read badly since it wasn't being treated like one. After enclosing the command after kustomize in quotes, the installation ran successfully as shown in the screenshot below.

![Screenshot 2021-03-09 at 21 14 22](https://user-images.githubusercontent.com/17182751/110543741-c1d5cd00-813b-11eb-9cb4-149a918f9331.png)

**How to test it**

Either merge the branch I worked on in 4.2 and try running it again following the steps to reproduce it. Or simply add the quotes/slash in the `kustomize.py file` line 581 and line 589 and run again.
