### PR TITLE
build: use pip3 editable install instead of setup.py develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := develop
 
 develop:
-	/usr/bin/env python3 setup.py develop
+	pip3 install -e .
 
 install:
 	pip3 install .


### PR DESCRIPTION
The changeset replaces deprecated `setup.py develop` in favor of `pip3 install -e`.