### PR TITLE
fix: set unique session-cookie-name of ingresses to avoid collision

### DIFF
--- a/pygluu/kubernetes/templates/helm/gluu/charts/nginx-ingress/templates/ingress-legacy.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/nginx-ingress/templates/ingress-legacy.yaml
@@ -19,7 +19,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "base-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
 {{- if .Values.ingress.adminUiAdditionalAnnotations }}
 {{ toYaml .Values.ingress.adminUiAdditionalAnnotations | indent 4 }}
@@ -586,7 +586,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "passport-statefulset-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 {{- if .Values.ingress.passportAdditionalAnnotations }}
@@ -640,7 +640,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "shib-stateful-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 {{- if .Values.ingress.additionalAnnotations }}
@@ -689,7 +689,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "admin-ui-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 {{- if .Values.ingress.adminUiAdditionalAnnotations }}
@@ -742,7 +742,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/session-cookie-hash: sha1
-    nginx.ingress.kubernetes.io/session-cookie-name: route
+    nginx.ingress.kubernetes.io/session-cookie-name: "casa-route"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 {{- if .Values.ingress.casaAdditionalAnnotations }}
 {{ toYaml .Values.ingress.casaAdditionalAnnotations | indent 4 }}

--- a/pygluu/kubernetes/templates/helm/gluu/charts/nginx-ingress/templates/ingress.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/nginx-ingress/templates/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "base-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
 {{- if .Values.ingress.adminUiAdditionalAnnotations }}
 {{ toYaml .Values.ingress.adminUiAdditionalAnnotations | indent 4 }}
@@ -724,7 +724,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "passport-statefulset-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 {{- if .Values.ingress.passportAdditionalAnnotations }}
@@ -779,7 +779,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "shib-stateful-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 {{- if .Values.ingress.shibAdditionalAnnotations }}
@@ -833,7 +833,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "admin-ui-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 {{- if .Values.ingress.adminUiAdditionalAnnotations }}
@@ -888,7 +888,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/session-cookie-hash: sha1
-    nginx.ingress.kubernetes.io/session-cookie-name: route
+    nginx.ingress.kubernetes.io/session-cookie-name: "casa-route"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 {{- if .Values.ingress.casaAdditionalAnnotations }}
 {{ toYaml .Values.ingress.casaAdditionalAnnotations | indent 4 }}

--- a/pygluu/kubernetes/templates/nginx/nginx.yaml
+++ b/pygluu/kubernetes/templates/nginx/nginx.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "base-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
 spec:
   tls:
@@ -265,7 +265,7 @@ metadata:
     nginx.org/ssl-services: "oxtrust"
     nginx.ingress.kubernetes.io/app-root: "/identity"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "stateful-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 spec:
@@ -300,7 +300,7 @@ metadata:
     nginx.org/ssl-services: "casa"
     nginx.ingress.kubernetes.io/app-root: "/casa"
     nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-name: "casa-route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
 spec:


### PR DESCRIPTION
The changeset introduces unique name per ingress' `session-cookie-name`.

Ref: #536 