### PR TITLE
fix: missing pods and pods/exec permission for default Role

### DIFF
--- a/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/roles.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/roles.yaml
@@ -11,5 +11,5 @@ metadata:
 {{- end }}
 rules:
 - apiGroups: [""] # "" refers to the core API group
-  resources: ["configmaps", "secrets"]
+  resources: ["configmaps", "secrets", "pods", "pods/exec"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
The changeset add the following missing rules for default Role.

- `pods` (listing pods from inside the container)
- `pods/exec` (for running command inside the container)