### PR TITLE
fix: error converting YAML to JSON using pygluu-kubernetes installer

### DIFF
--- a/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/rolebinding.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/config/templates/rolebinding.yaml
@@ -18,14 +18,14 @@ roleRef:
   name: {{ .Release.Namespace }}-gluu-role # this must match the name of the Role or ClusterRole you wish to bind to
   apiGroup: rbac.authorization.k8s.io
 
-  ---
+---
 
-{{- if.Values.global.istio.ingress}} 
+{{- if.Values.global.istio.ingress}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: istio-rolebinding
-  namespace: {{.Values.global.istio.namespace | quote}} 
+  namespace: {{.Values.global.istio.namespace | quote}}
 {{- if .Values.additionalAnnotations }}
   annotations:
 {{ toYaml .Values.additionalAnnotations | indent 4 }}


### PR DESCRIPTION
The changeset fixes indentation in `helm/charts/config/templates/rolebinding.yaml` file.

Closes #586 