### PR TITLE
fix: use interval-based cronjob schedule syntax

### DIFF
--- a/pygluu/kubernetes/templates/helm/gluu/charts/oxauth-key-rotation/templates/cronjobs.yaml
+++ b/pygluu/kubernetes/templates/helm/gluu/charts/oxauth-key-rotation/templates/cronjobs.yaml
@@ -16,7 +16,7 @@ metadata:
 {{ toYaml .Values.additionalAnnotations | indent 4 }}
 {{- end }}
 spec:
-  schedule: "0 */{{ .Values.keysLife }} * * *"
+  schedule: "@every {{ .Values.keysLife }}h"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
The changeset introduces `@every` cron syntax for oxauth-key-rotation.

Closes #593 